### PR TITLE
:tada: Appearance tab & Status view mode

### DIFF
--- a/packages/api/prisma/migrations/20211102101051_/migration.sql
+++ b/packages/api/prisma/migrations/20211102101051_/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "StatusViewMode" AS ENUM ('FULL_ROW_COLOR', 'DOT_COLOR');
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "statusViewMode" "StatusViewMode" NOT NULL DEFAULT E'DOT_COLOR';

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -76,8 +76,6 @@ model User {
   tempPassword    String?
   statusViewMode  StatusViewMode  @default(DOT_COLOR)
 
-
-
   // relational data
   citizens             Citizen[]
   cads                 cad[]

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -74,6 +74,9 @@ model User {
   whitelistStatus WhitelistStatus @default(ACCEPTED)
   isDarkTheme     Boolean         @default(true)
   tempPassword    String?
+  statusViewMode  StatusViewMode  @default(DOT_COLOR)
+
+
 
   // relational data
   citizens             Citizen[]
@@ -94,6 +97,11 @@ model User {
   emsFdDeputies        EmsFdDeputy[]
   TaxiCall             TaxiCall[]
   TruckLog             TruckLog[]
+}
+
+enum StatusViewMode {
+  FULL_ROW_COLOR
+  DOT_COLOR
 }
 
 model Citizen {

--- a/packages/api/src/controllers/auth/User.ts
+++ b/packages/api/src/controllers/auth/User.ts
@@ -21,7 +21,7 @@ export class AccountController {
 
   @Patch("/")
   async patchAuthUser(@BodyParams() body: JsonRequestBody, @Context("user") user: User) {
-    const { username, isDarkTheme } = body.toJSON();
+    const { username, isDarkTheme, statusViewMode } = body.toJSON();
 
     const existing = await prisma.user.findUnique({
       where: {
@@ -40,6 +40,7 @@ export class AccountController {
       data: {
         username,
         isDarkTheme,
+        statusViewMode,
       },
     });
 

--- a/packages/api/src/lib/auth.ts
+++ b/packages/api/src/lib/auth.ts
@@ -22,6 +22,7 @@ export const userProperties = {
   whitelistStatus: true,
   isDarkTheme: true,
   tempPassword: true,
+  statusViewMode: true,
 };
 
 export async function getSessionUser(req: Req, throwErrors = false): Promise<User> {

--- a/packages/client/locales/en/account.json
+++ b/packages/client/locales/en/account.json
@@ -3,7 +3,8 @@
     "account": "Account",
     "accountInfo": "Account Info",
     "accountSettings": "Account Settings",
-    "passwordSettings": "Password Settings"
+    "passwordSettings": "Password Settings",
+    "appearanceSettings": "Appearance Settings"
   },
   "Notifications": {
     "CITIZEN_DELETED": "<span>{citizen}</span> was deleted. Reason: {reason}"

--- a/packages/client/src/components/account/AppearanceTab.tsx
+++ b/packages/client/src/components/account/AppearanceTab.tsx
@@ -1,0 +1,71 @@
+import * as React from "react";
+import { Tab } from "@headlessui/react";
+import { Button } from "components/Button";
+import { Error } from "components/form/Error";
+import { FormField } from "components/form/FormField";
+import { Toggle } from "components/form/Toggle";
+import { useAuth } from "context/AuthContext";
+import { Form, Formik } from "formik";
+import useFetch from "lib/useFetch";
+import { useTranslations } from "use-intl";
+import { StatusViewMode } from "types/prisma";
+import { Select } from "components/form/Select";
+
+const LABELS = {
+  [StatusViewMode.DOT_COLOR]: "Dot color",
+  [StatusViewMode.FULL_ROW_COLOR]: "Full row color",
+};
+
+export const AppearanceTab = () => {
+  const { user } = useAuth();
+  const t = useTranslations("Account");
+  const { execute, state } = useFetch();
+  const common = useTranslations("Common");
+
+  const INITIAL_VALUES = {
+    isDarkTheme: user?.isDarkTheme ?? true,
+    statusViewMode: user?.statusViewMode ?? StatusViewMode.DOT_COLOR,
+  };
+
+  async function onSubmit(data: typeof INITIAL_VALUES) {
+    const { json } = await execute("/user", {
+      method: "PATCH",
+      data: { ...user, ...data },
+    });
+
+    console.log({ json });
+  }
+
+  return (
+    <Tab.Panel className="bg-white rounded-xl p-3">
+      <h3 className="text-2xl font-semibold">{t("appearanceSettings")}</h3>
+      <Formik onSubmit={onSubmit} initialValues={INITIAL_VALUES}>
+        {({ handleChange, values, errors }) => (
+          <Form className="mt-2">
+            <FormField label="Dark Theme">
+              <Toggle toggled={values.isDarkTheme} onClick={handleChange} name="isDarkTheme" />
+              <Error>{errors.isDarkTheme}</Error>
+            </FormField>
+
+            <FormField label="Status View">
+              <Select
+                values={Object.values(StatusViewMode).map((v) => ({
+                  value: v,
+                  label: LABELS[v],
+                }))}
+                value={values.statusViewMode}
+                onChange={handleChange}
+                name="statusViewMode"
+              />
+              <Error>{errors.statusViewMode}</Error>
+            </FormField>
+
+            <Button type="submit" disabled={state === "loading"}>
+              {common("save")}
+            </Button>
+          </Form>
+        )}
+      </Formik>
+    </Tab.Panel>
+  );
+};

--- a/packages/client/src/components/account/ChangePasswordArea.tsx
+++ b/packages/client/src/components/account/ChangePasswordArea.tsx
@@ -76,7 +76,9 @@ export const ChangePasswordArea = () => {
               <Error>{errors.confirmPassword}</Error>
             </FormField>
 
-            <Button disabled={state === "loading"}>{common("save")}</Button>
+            <Button type="submit" disabled={state === "loading"}>
+              {common("save")}
+            </Button>
           </Form>
         )}
       </Formik>

--- a/packages/client/src/components/dispatch/ActiveDeputies.tsx
+++ b/packages/client/src/components/dispatch/ActiveDeputies.tsx
@@ -9,6 +9,8 @@ import { useActiveDeputies } from "hooks/useActiveDeputies";
 import { useRouter } from "next/router";
 import { makeImageUrl, makeUnitName } from "lib/utils";
 import { useGenerateCallsign } from "hooks/useGenerateCallsign";
+import { StatusViewMode } from "types/prisma";
+import { useAuth } from "context/AuthContext";
 
 export const ActiveDeputies = () => {
   const { activeDeputies } = useActiveDeputies();
@@ -16,6 +18,7 @@ export const ActiveDeputies = () => {
   const common = useTranslations("Common");
   const { openModal } = useModal();
   const generateCallsign = useGenerateCallsign();
+  const { user } = useAuth();
 
   const router = useRouter();
   const isDispatch = router.pathname === "/dispatch";
@@ -50,37 +53,44 @@ export const ActiveDeputies = () => {
                 </tr>
               </thead>
               <tbody>
-                {activeDeputies.map((deputy) => (
-                  <tr key={deputy.id}>
-                    <td className="capitalize flex items-center">
-                      {deputy.imageId ? (
-                        <img
-                          className="rounded-md w-[30px] h-[30px] object-cover mr-2"
-                          draggable={false}
-                          src={makeImageUrl("units", deputy.imageId)}
-                        />
-                      ) : null}
-                      {generateCallsign(deputy)} {makeUnitName(deputy)}
-                    </td>
-                    <td>{String(deputy.badgeNumber)}</td>
-                    <td>{deputy.department.value.value}</td>
-                    <td>{deputy.division.value.value}</td>
-                    <td className="flex items-center">
-                      <span
-                        style={{ background: deputy.status?.color }}
-                        className="block w-3 h-3 rounded-full mr-2"
-                      />
-                      {deputy.status?.value?.value}
-                    </td>
-                    {isDispatch ? (
-                      <td className="w-36">
-                        <Button onClick={() => handleEditClick(deputy)} small variant="success">
-                          {common("manage")}
-                        </Button>
+                {activeDeputies.map((deputy) => {
+                  const color = deputy.status?.color;
+                  const useDot = user?.statusViewMode === StatusViewMode.DOT_COLOR;
+
+                  return (
+                    <tr style={{ background: !useDot ? color : undefined }} key={deputy.id}>
+                      <td className="capitalize flex items-center">
+                        {deputy.imageId ? (
+                          <img
+                            className="rounded-md w-[30px] h-[30px] object-cover mr-2"
+                            draggable={false}
+                            src={makeImageUrl("units", deputy.imageId)}
+                          />
+                        ) : null}
+                        {generateCallsign(deputy)} {makeUnitName(deputy)}
                       </td>
-                    ) : null}
-                  </tr>
-                ))}
+                      <td>{String(deputy.badgeNumber)}</td>
+                      <td>{deputy.department.value.value}</td>
+                      <td>{deputy.division.value.value}</td>
+                      <td className="flex items-center">
+                        {useDot ? (
+                          <span
+                            style={{ background: deputy.status?.color }}
+                            className="block w-3 h-3 rounded-full mr-2"
+                          />
+                        ) : null}
+                        {deputy.status?.value?.value}
+                      </td>
+                      {isDispatch ? (
+                        <td className="w-36">
+                          <Button onClick={() => handleEditClick(deputy)} small variant="success">
+                            {common("manage")}
+                          </Button>
+                        </td>
+                      ) : null}
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>

--- a/packages/client/src/components/dispatch/ActiveOfficers.tsx
+++ b/packages/client/src/components/dispatch/ActiveOfficers.tsx
@@ -9,6 +9,8 @@ import { useActiveOfficers } from "hooks/useActiveOfficers";
 import { useRouter } from "next/router";
 import { makeImageUrl, makeUnitName } from "lib/utils";
 import { useGenerateCallsign } from "hooks/useGenerateCallsign";
+import { useAuth } from "context/AuthContext";
+import { StatusViewMode } from "types/prisma";
 
 export const ActiveOfficers = () => {
   const { activeOfficers } = useActiveOfficers();
@@ -16,6 +18,7 @@ export const ActiveOfficers = () => {
   const common = useTranslations("Common");
   const { openModal } = useModal();
   const generateCallsign = useGenerateCallsign();
+  const { user } = useAuth();
 
   const router = useRouter();
   const isDispatch = router.pathname === "/dispatch";
@@ -50,37 +53,44 @@ export const ActiveOfficers = () => {
                 </tr>
               </thead>
               <tbody>
-                {activeOfficers.map((officer) => (
-                  <tr key={officer.id}>
-                    <td className="capitalize flex items-center">
-                      {officer.imageId ? (
-                        <img
-                          className="rounded-md w-[30px] h-[30px] object-cover mr-2"
-                          draggable={false}
-                          src={makeImageUrl("units", officer.imageId)}
-                        />
-                      ) : null}
-                      {generateCallsign(officer)} {makeUnitName(officer)}
-                    </td>
-                    <td>{String(officer.badgeNumber)}</td>
-                    <td>{officer.department.value.value}</td>
-                    <td>{officer.division.value.value}</td>
-                    <td className="flex items-center">
-                      <span
-                        style={{ background: officer.status?.color }}
-                        className="block w-3 h-3 rounded-full mr-2"
-                      />
-                      {officer.status?.value?.value}
-                    </td>
-                    {isDispatch ? (
-                      <td className="w-36">
-                        <Button onClick={() => handleEditClick(officer)} small variant="success">
-                          {common("manage")}
-                        </Button>
+                {activeOfficers.map((officer) => {
+                  const color = officer.status?.color;
+                  const useDot = user?.statusViewMode === StatusViewMode.DOT_COLOR;
+
+                  return (
+                    <tr style={{ background: !useDot ? color : undefined }} key={officer.id}>
+                      <td className="capitalize flex items-center">
+                        {officer.imageId ? (
+                          <img
+                            className="rounded-md w-[30px] h-[30px] object-cover mr-2"
+                            draggable={false}
+                            src={makeImageUrl("units", officer.imageId)}
+                          />
+                        ) : null}
+                        {generateCallsign(officer)} {makeUnitName(officer)}
                       </td>
-                    ) : null}
-                  </tr>
-                ))}
+                      <td>{String(officer.badgeNumber)}</td>
+                      <td>{officer.department.value.value}</td>
+                      <td>{officer.division.value.value}</td>
+                      <td className="flex items-center">
+                        {useDot ? (
+                          <span
+                            style={{ background: officer.status?.color }}
+                            className="block w-3 h-3 rounded-full mr-2"
+                          />
+                        ) : null}
+                        {officer.status?.value?.value}
+                      </td>
+                      {isDispatch ? (
+                        <td className="w-36">
+                          <Button onClick={() => handleEditClick(officer)} small variant="success">
+                            {common("manage")}
+                          </Button>
+                        </td>
+                      ) : null}
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>

--- a/packages/client/src/pages/account.tsx
+++ b/packages/client/src/pages/account.tsx
@@ -16,6 +16,7 @@ import useFetch from "lib/useFetch";
 import { Toggle } from "components/form/Toggle";
 import { Button } from "components/Button";
 import { ChangePasswordArea } from "components/account/ChangePasswordArea";
+import { AppearanceTab } from "components/account/AppearanceTab";
 
 export default function Account() {
   const { user } = useAuth();
@@ -23,7 +24,7 @@ export default function Account() {
   const { execute, state } = useFetch();
   const common = useTranslations("Common");
 
-  const TABS_TITLES = [t("accountInfo"), t("accountSettings")];
+  const TABS_TITLES = [t("accountInfo"), t("accountSettings"), t("appearanceSettings")];
 
   const INITIAL_VALUES = {
     username: user?.username ?? "",
@@ -91,13 +92,16 @@ export default function Account() {
                         <Error>{errors.isDarkTheme}</Error>
                       </FormField>
 
-                      <Button disabled={state === "loading"}>{common("save")}</Button>
+                      <Button type="submit" disabled={state === "loading"}>
+                        {common("save")}
+                      </Button>
                     </Form>
                   )}
                 </Formik>
 
                 <ChangePasswordArea />
               </Tab.Panel>
+              <AppearanceTab />
             </Tab.Panels>
           </TabsContainer>
         </div>

--- a/packages/client/src/types/prisma.ts
+++ b/packages/client/src/types/prisma.ts
@@ -67,6 +67,7 @@ export type User = {
   whitelistStatus: WhitelistStatus;
   isDarkTheme: boolean;
   hasTempPassword: boolean;
+  statusViewMode: StatusViewMode;
 };
 
 /**
@@ -519,6 +520,13 @@ export type LeoIncident = {
 
 // Based on
 // https://github.com/microsoft/TypeScript/issues/3192#issuecomment-261720275
+
+export const StatusViewMode = {
+  FULL_ROW_COLOR: "FULL_ROW_COLOR",
+  DOT_COLOR: "DOT_COLOR",
+} as const;
+
+export type StatusViewMode = typeof StatusViewMode[keyof typeof StatusViewMode];
 
 export const rank = {
   OWNER: "OWNER",


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

Full row:
![image](https://user-images.githubusercontent.com/53900565/139830746-198969dd-e2e4-4fc3-9758-ea5b301f1ef8.png)

Dot color:
![image](https://user-images.githubusercontent.com/53900565/139830754-a841b876-a6fe-4bac-abdf-6a29db1f5061.png)


## Bug

- [ ] Related issues linked using `closes: #number`

## Feature

- [x] Related issues linked using closes: #106 
- [x] There is only 1 db migration with no breaking changes.

## Translations

- [ ] `.json` files are formatted: `yarn format`
- [ ] Translations are correct
- [ ] New translation? It's been added to `next.config.js`
