### PR TITLE
:tada: feat: able to unassign from call

### DIFF
--- a/packages/client/locales/en/calls.json
+++ b/packages/client/locales/en/calls.json
@@ -9,6 +9,7 @@
     "no911Calls": "There are no 911 calls yet.",
     "assignToCall": "Assign to call",
     "assignedUnit": "Assigned Unit",
+    "unassignFromCall": "Unassign from call",
     "location": "Location",
     "caller": "Caller",
     "createTowCall": "Create tow call",

--- a/packages/client/src/components/leo/ActiveCalls.tsx
+++ b/packages/client/src/components/leo/ActiveCalls.tsx
@@ -111,7 +111,14 @@ export function ActiveCalls() {
   }
 
   async function handleAssignToCall(call: Full911Call) {
-    await execute(`/911-calls/assign-to/${call.id}`, {
+    await execute(`/911-calls/assign/${call.id}`, {
+      method: "POST",
+      data: { unit: unit?.id },
+    });
+  }
+
+  async function handleUnassignFromCall(call: Full911Call) {
+    await execute(`/911-calls/unassign/${call.id}`, {
       method: "POST",
       data: { unit: unit?.id },
     });
@@ -194,7 +201,16 @@ export function ActiveCalls() {
                               >
                                 {t("viewEvents")}
                               </Button>
-                              {isUnitAssigned ? null : (
+                              {isUnitAssigned ? (
+                                <Button
+                                  className="ml-2"
+                                  disabled={!unit}
+                                  small
+                                  onClick={() => handleUnassignFromCall(call)}
+                                >
+                                  {t("unassignFromCall")}
+                                </Button>
+                              ) : (
                                 <Button
                                   className="ml-2"
                                   disabled={!unit}


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

## Bug

- [ ] Related issues linked using `closes: #number`

## Feature

- [x] Related issues linked using closes: #311 
- [x] There is only 1 db migration with no breaking changes.

## Translations

- [ ] `.json` files are formatted: `yarn format`
- [ ] Translations are correct
- [ ] New translation? It's been added to `next.config.js`
