### PR TITLE
:tada: feat: set units off-duty on logout

### DIFF
--- a/packages/api/src/lib/leo/handleStartEndOfficerLog.ts
+++ b/packages/api/src/lib/leo/handleStartEndOfficerLog.ts
@@ -1,0 +1,76 @@
+import { Officer, ShouldDoType } from "@prisma/client";
+import { callInclude } from "controllers/dispatch/Calls911Controller";
+import { prisma } from "lib/prisma";
+import { Socket } from "services/SocketService";
+
+interface Options {
+  shouldDo: ShouldDoType;
+  officer: Officer;
+  socket: Socket;
+  userId: string;
+}
+
+export async function handleStartEndOfficerLog(options: Options) {
+  /**
+   * find an officer-log that has not ended yet.
+   */
+  const officerLog = await prisma.officerLog.findFirst({
+    where: {
+      officerId: options.officer.id,
+      endedAt: null,
+    },
+  });
+
+  if (options.shouldDo === ShouldDoType.SET_ON_DUTY) {
+    /**
+     * if the officer is being set on-duty, it will create the officer-log.
+     */
+    if (!officerLog) {
+      await prisma.officerLog.create({
+        data: {
+          officerId: options.officer.id,
+          userId: options.userId,
+          startedAt: new Date(),
+        },
+      });
+    }
+  } else if (options.shouldDo === ShouldDoType.SET_OFF_DUTY) {
+    const calls = await prisma.call911.findMany({
+      where: {
+        assignedUnits: { some: { officerId: options.officer.id } },
+      },
+      include: {
+        assignedUnits: callInclude.assignedUnits,
+      },
+    });
+
+    calls.forEach((call) => {
+      /**
+       * remove officer from assigned units then emit via socket
+       */
+      const assignedUnits = call.assignedUnits.filter((v) => v.officerId !== options.officer.id);
+      options.socket.emitUpdate911Call({ ...call, assignedUnits });
+    });
+
+    // unassign officer from call
+    await prisma.assignedUnit.deleteMany({
+      where: {
+        officerId: options.officer.id,
+      },
+    });
+
+    /**
+     * end the officer-log.
+     */
+    if (officerLog) {
+      await prisma.officerLog.update({
+        where: {
+          id: officerLog.id,
+        },
+        data: {
+          endedAt: new Date(),
+        },
+      });
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

## Bug

- [ ] Related issues linked using `closes: #number`

## Feature

- [x] Related issues linked using closes: #339 
- [x] There is only 1 db migration with no breaking changes.

## Translations

- [ ] `.json` files are formatted: `yarn format`
- [ ] Translations are correct
- [ ] New translation? It's been added to `next.config.js`
