### PR TITLE
removed not needed if statement that would bug build

### DIFF
--- a/scripts/copy-env.mjs
+++ b/scripts/copy-env.mjs
@@ -6,20 +6,13 @@ import { readFileSync, writeFileSync } from "node:fs";
 
 function addPortToClientPackageJson() {
   if (process.env.NODE_ENV === "development") return;
-  let dir = join(process.cwd(), "package.json");
-
-  if (!dir.includes("/packages/client")) {
-    dir = join(process.cwd(), "packages/client", "package.json");
-  }
-
+  let dir = join(process.cwd(), "/packages/client/package.json");
   let json = readFileSync(dir, "utf8");
   const port = process.env.PORT_CLIENT;
-
   if (port) {
     json = JSON.parse(json);
     json.scripts.start = `next start -p ${port}`;
     json = JSON.stringify(json, null, 2);
-
     writeFileSync(dir, json, (err) => {
       if (err) {
         console.log(err);


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

## Bug

- [ ] Related issues linked using `closes: #number`

## Feature

- [ ] Related issues linked using `closes: #number`
- [ ] There is only 1 db migration with no breaking changes.

## Translations

- [ ] `.json` files are formatted: `yarn format`
- [ ] Translations are correct
- [ ] New translation? It's been added to `next.config.js`

this PR prevents of this new bug i discovered

@snailycad/client:copy-env: Error: ENOENT: no such file or directory, open 'C:\Users\sharki\Desktop\snaily-cadv4-main\packages\client\packages\client\package.json'   

this if conditional bugged out the "dir" variable and added an invalid path to open the package.json file