### PR TITLE
:tada: feat: allow attaching situation codes to calls

### DIFF
--- a/packages/api/prisma/migrations/20220217150844_/migration.sql
+++ b/packages/api/prisma/migrations/20220217150844_/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Call911" ADD COLUMN     "situationCodeId" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "Call911" ADD CONSTRAINT "Call911_situationCodeId_fkey" FOREIGN KEY ("situationCodeId") REFERENCES "StatusValue"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -672,6 +672,7 @@ model StatusValue {
   officerStatusToValue Officer[]         @relation("officerStatusToValue")
   emsFdStatusToValue   EmsFdDeputy[]     @relation("emsFdStatusToValue")
   CombinedLeoUnit      CombinedLeoUnit[] @relation("combinedUnitStatusToValue")
+  Call911              Call911[]
 }
 
 model OfficerLog {
@@ -768,6 +769,8 @@ model Call911 {
   descriptionData Json?
   name            String            @db.VarChar(255)
   ended           Boolean?          @default(false)
+  situationCode   StatusValue?      @relation(fields: [situationCodeId], references: [id])
+  situationCodeId String?
   divisions       DivisionValue[]
   departments     DepartmentValue[]
   events          Call911Event[]

--- a/packages/api/src/controllers/dispatch/911-calls/Calls911Controller.ts
+++ b/packages/api/src/controllers/dispatch/911-calls/Calls911Controller.ts
@@ -34,6 +34,7 @@ export const callInclude = {
   incidents: true,
   departments: { include: leoProperties.department.include },
   divisions: { include: leoProperties.division.include },
+  situationCode: { include: { value: true } },
 };
 
 @Controller("/911-calls")
@@ -69,6 +70,7 @@ export class Calls911Controller {
         descriptionData: data.descriptionData,
         name: data.name,
         userId: user.id || undefined,
+        situationCodeId: data.situationCode ?? null,
       },
       include: callInclude,
     });
@@ -164,6 +166,7 @@ export class Calls911Controller {
         userId: ctx.get("user").id,
         positionId: shouldRemovePosition ? null : position?.id ?? call.positionId,
         descriptionData: data.descriptionData,
+        situationCodeId: data.situationCode === null ? null : data.situationCode,
       },
     });
 

--- a/packages/client/locales/en/calls.json
+++ b/packages/client/locales/en/calls.json
@@ -40,6 +40,7 @@
     "toggleCall": "Toggle call",
     "removeMarker": "Remove marker",
     "setMarker": "Set marker",
+    "situationCode": "Situation Code",
     "alert_purgeSelectedCalls": "Are you sure you want to purge {length} item(s)? This will delete {length} item(s) from the database. This action cannot be undone.",
     "alert_deleteCallEvent": "Are you sure you want to delete this event? This action cannot be undone.",
     "alert_end911Call": "Are you sure you want to end this call?",

--- a/packages/client/src/components/leo/ActiveCalls.tsx
+++ b/packages/client/src/components/leo/ActiveCalls.tsx
@@ -184,6 +184,7 @@ function ActiveCallsInner() {
                         {common("viewDescription")}
                       </Button>
                     ),
+                  situationCode: call.situationCode?.value.value ?? common("none"),
                   updatedAt: <FullDate>{call.updatedAt}</FullDate>,
                   assignedUnits: call.assignedUnits.map(makeUnit).join(", ") || common("none"),
                   actions: (
@@ -235,6 +236,7 @@ function ActiveCallsInner() {
               { Header: t("caller"), accessor: "name" },
               { Header: t("location"), accessor: "location" },
               { Header: common("description"), accessor: "description" },
+              { Header: t("situationCode"), accessor: "situationCode" },
               { Header: common("updatedAt"), accessor: "updatedAt" },
               { Header: t("assignedUnits"), accessor: "assignedUnits" },
               { Header: common("actions"), accessor: "actions" },

--- a/packages/client/src/components/modals/Manage911CallModal.tsx
+++ b/packages/client/src/components/modals/Manage911CallModal.tsx
@@ -18,7 +18,7 @@ import { SocketEvents } from "@snailycad/config";
 import { CallEventsArea } from "./911Call/EventsArea";
 import { useGenerateCallsign } from "hooks/useGenerateCallsign";
 import { makeUnitName } from "lib/utils";
-import type { CombinedLeoUnit } from "@snailycad/types";
+import { StatusValueType, type CombinedLeoUnit } from "@snailycad/types";
 import { FormRow } from "components/form/FormRow";
 import { handleValidate } from "lib/handleValidate";
 import { CREATE_911_CALL } from "@snailycad/schemas";
@@ -42,7 +42,7 @@ export function Manage911CallModal({ setCall, call, onClose }: Props) {
   const isDispatch = router.pathname.startsWith("/dispatch") && user?.isDispatch;
   const { allOfficers, allDeputies, activeDeputies, activeOfficers } = useDispatchState();
   const generateCallsign = useGenerateCallsign();
-  const { department, division } = useValues();
+  const { department, division, codes10 } = useValues();
   const isDisabled = !router.pathname.includes("/citizen") && !isDispatch;
 
   const allUnits = [...allOfficers, ...allDeputies] as (FullDeputy | CombinedLeoUnit)[];
@@ -202,6 +202,7 @@ export function Manage911CallModal({ setCall, call, onClose }: Props) {
     descriptionData: dataToSlate(call),
     departments: call?.departments?.map((dep) => ({ value: dep.id, label: dep.value.value })) ?? [],
     divisions: call?.divisions?.map((dep) => ({ value: dep.id, label: dep.value.value })) ?? [],
+    situationCode: call?.situationCodeId ?? null,
     assignedUnits:
       call?.assignedUnits.map((unit) => ({
         label: makeLabel(unit.unit.id),
@@ -319,6 +320,22 @@ export function Manage911CallModal({ setCall, call, onClose }: Props) {
                       />
                     </FormField>
                   </FormRow>
+
+                  <FormField errorMessage={errors.situationCode} label={t("situationCode")}>
+                    <Select
+                      isClearable
+                      name="situationCode"
+                      value={values.situationCode}
+                      values={codes10.values
+                        .filter((v) => v.type === StatusValueType.SITUATION_CODE)
+                        .map((division) => ({
+                          label: division.value.value,
+                          value: division.id,
+                        }))}
+                      onChange={handleChange}
+                      disabled={isDisabled}
+                    />
+                  </FormField>
                 </>
               )}
 

--- a/packages/schemas/src/dispatch/911-calls.ts
+++ b/packages/schemas/src/dispatch/911-calls.ts
@@ -11,6 +11,7 @@ export const CREATE_911_CALL = z.object({
   position: z.any().optional(),
   departments: z.array(z.string().or(SELECT_VALUE)).optional(),
   divisions: z.array(z.string().or(SELECT_VALUE)).optional(),
+  situationCode: z.string().max(255).nullable().optional(),
 });
 
 export const LINK_INCIDENT_TO_CALL = z.object({

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -669,6 +669,8 @@ export interface Call911 {
   descriptionData: DescriptionData | null;
   name: string;
   ended: boolean | null;
+  situationCodeId: string | null;
+  situationCode: StatusValue | null;
   departments?: DepartmentValue[];
   divisions?: DivisionValue[];
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

## Bug

- [ ] Related issues linked using `closes: #number`

## Feature

- [x] Related issues linked using closes: #403 
- [x] There is only 1 db migration with no breaking changes.

## Translations

- [ ] `.json` files are formatted: `yarn format`
- [ ] Translations are correct
- [ ] New translation? It's been added to `next.config.js`
