### PR TITLE
🔨 chore: add `@snailycad/utils` package

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -32,6 +32,7 @@
     "@snailycad/config": "1.0.0-beta.59",
     "@snailycad/schemas": "1.0.0-beta.59",
     "@snailycad/types": "1.0.0-beta.59",
+    "@snailycad/utils": "1.0.0-beta.59",
     "@tsed/common": "^6.102.5",
     "@tsed/core": "^6.102.5",
     "@tsed/di": "^6.102.5",

--- a/packages/api/prisma/migrations/20220220123028_/migration.sql
+++ b/packages/api/prisma/migrations/20220220123028_/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "MiscCadSettings" ALTER COLUMN "pairedUnitTemplate" SET DEFAULT E'1A-{callsign1}';

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -53,7 +53,7 @@ model MiscCadSettings {
   // max units a user can create with a department
   maxDepartmentsEachPerUser Int?
   callsignTemplate          String   @default("{department}{callsign1} - {callsign2}{division}") @db.Text
-  pairedUnitTemplate        String?  @default("1A-{callsign2}") @db.Text
+  pairedUnitTemplate        String?  @default("1A-{callsign1}") @db.Text
   pairedUnitSymbol          String?  @default("A") @db.VarChar(255)
   signal100Enabled          Boolean  @default(false)
   liveMapURL                String?  @db.Text

--- a/packages/api/src/lib/leo/handleStartEndOfficerLog.ts
+++ b/packages/api/src/lib/leo/handleStartEndOfficerLog.ts
@@ -5,7 +5,7 @@ import type { Socket } from "services/SocketService";
 
 interface Options {
   shouldDo: ShouldDoType;
-  officer: Officer;
+  officer: Omit<Officer, "divisionId">;
   socket: Socket;
   userId: string;
 }

--- a/packages/api/src/migrations/pairedSymbolToTemplate.ts
+++ b/packages/api/src/migrations/pairedSymbolToTemplate.ts
@@ -1,7 +1,7 @@
 import { prisma } from "lib/prisma";
 
 const DEFAULT_SYMBOL = "A" as const;
-const DEFAULT_TEMPLATE = "1A-{callsign2}";
+const DEFAULT_TEMPLATE = "1A-{callsign1}";
 
 export async function pairedSymbolToTemplate() {
   const settings = await prisma.miscCadSettings.findFirst({
@@ -18,7 +18,7 @@ export async function pairedSymbolToTemplate() {
     await prisma.miscCadSettings.update({
       where: { id: settings.id },
       data: {
-        pairedUnitTemplate: `1${settings.pairedUnitSymbol}-{callsign2}`,
+        pairedUnitTemplate: `1${settings.pairedUnitSymbol}-{callsign1}`,
         pairedUnitSymbol: "",
       },
     });

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -30,6 +30,7 @@
     "@snailycad/config": "1.0.0-beta.59",
     "@snailycad/schemas": "1.0.0-beta.59",
     "@snailycad/types": "1.0.0-beta.59",
+    "@snailycad/utils": "1.0.0-beta.59",
     "axios": "^0.26.0",
     "date-fns": "^2.28.0",
     "formik": "^2.2.9",

--- a/packages/client/src/components/dispatch/ActiveOfficers.tsx
+++ b/packages/client/src/components/dispatch/ActiveOfficers.tsx
@@ -139,7 +139,7 @@ export function ActiveOfficers() {
                     ) : null}
                     {"officers" in officer ? (
                       <div className="flex items-center">
-                        {officer.callsign}
+                        {generateCallsign(officer, "pairedUnitTemplate")}
                         <span className="mx-4">
                           <ArrowRight />
                         </span>

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,3 +1,3 @@
 # @snailycad/utils
 
-TODO
+This is a module that is used to house utility functions used both in the client and API.

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,0 +1,3 @@
+# @snailycad/utils
+
+TODO

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@snailycad/utils",
+  "version": "1.0.0-beta.59",
+  "main": "./dist/index.js",
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@snailycad/types": "1.0.0-beta.59",
+    "tsup": "^5.11.13",
+    "typescript": "^4.5.5"
+  },
+  "tsup": {
+    "entry": [
+      "src/**/*.ts"
+    ],
+    "dts": true,
+    "bundle": false,
+    "platform": "node",
+    "target": "node16",
+    "silent": true
+  }
+}

--- a/packages/utils/src/callsign.ts
+++ b/packages/utils/src/callsign.ts
@@ -1,0 +1,42 @@
+import type { CombinedLeoUnit, EmsFdDeputy, Officer } from "@snailycad/types";
+
+// todo: Pick<T, P>
+type P = "callsign" | "callsign2" | "department" | "citizenId";
+type Unit = Pick<Officer, P | "divisions"> | Pick<EmsFdDeputy, P | "division"> | CombinedLeoUnit;
+
+export function generateCallsign(unit: Unit, template: string | null) {
+  const isCombined = !("citizenId" in unit);
+
+  const callsign = isCombined ? unit.officers[0]?.callsign : unit.callsign;
+  const callsign2 = isCombined ? null : unit.callsign2;
+  const department = isCombined ? null : unit.department;
+
+  const unitDivision =
+    "division" in unit ? unit.division : "divisions" in unit ? unit.divisions : [];
+
+  const [division] = Array.isArray(unitDivision) ? unitDivision : [unitDivision];
+
+  if (!template) {
+    return "";
+  }
+
+  const replacers = {
+    department: department?.callsign,
+    callsign1: callsign,
+    callsign2,
+    division: division?.callsign,
+  };
+
+  const templateArr: (string | null)[] = template.split(/[{}]/);
+  Object.entries(replacers).forEach(([replacer, value]) => {
+    const idx = templateArr.indexOf(replacer);
+
+    if (value) {
+      templateArr[idx] = value;
+    } else {
+      templateArr[idx] = null;
+    }
+  });
+
+  return templateArr.filter((v) => v !== null).join("");
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./callsign";

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "target": "ESNext",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "declaration": true,
+    "skipLibCheck": true
+  }
+}

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -18,9 +18,16 @@ for (const pkg of packages) {
   const packageJsonContentJSON = getJson(packageJsonPath);
   packageJsonContentJSON.version = version;
 
-  if (["api", "client"].includes(pkg)) {
+  if (["api", "client", "utils"].includes(pkg)) {
     for (const utilPkg of utilPackages) {
-      packageJsonContentJSON.dependencies[`@snailycad/${utilPkg}`] = version;
+      const isInDep = packageJsonContentJSON.dependencies?.[`@snailycad/${utilPkg}`];
+      const isInDevDep = packageJsonContentJSON.devDependencies?.[`@snailycad/${utilPkg}`];
+
+      if (isInDep) {
+        packageJsonContentJSON.dependencies[`@snailycad/${utilPkg}`] = version;
+      } else if (isInDevDep) {
+        packageJsonContentJSON.devDependencies[`@snailycad/${utilPkg}`] = version;
+      }
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1323,6 +1323,7 @@ __metadata:
     "@snailycad/config": 1.0.0-beta.59
     "@snailycad/schemas": 1.0.0-beta.59
     "@snailycad/types": 1.0.0-beta.59
+    "@snailycad/utils": 1.0.0-beta.59
     "@tsed/common": ^6.102.5
     "@tsed/core": ^6.102.5
     "@tsed/di": ^6.102.5

--- a/yarn.lock
+++ b/yarn.lock
@@ -1386,6 +1386,7 @@ __metadata:
     "@snailycad/config": 1.0.0-beta.59
     "@snailycad/schemas": 1.0.0-beta.59
     "@snailycad/types": 1.0.0-beta.59
+    "@snailycad/utils": 1.0.0-beta.59
     "@types/leaflet": ^1.7.9
     "@types/react": ^17.0.39
     "@types/react-dom": ^17.0.11
@@ -1461,6 +1462,16 @@ __metadata:
     type-fest: ^2.11.2
     typescript: ^4.5.5
     zod: ^3.11.6
+  languageName: unknown
+  linkType: soft
+
+"@snailycad/utils@1.0.0-beta.59, @snailycad/utils@workspace:packages/utils":
+  version: 0.0.0-use.local
+  resolution: "@snailycad/utils@workspace:packages/utils"
+  dependencies:
+    "@snailycad/types": 1.0.0-beta.59
+    tsup: ^5.11.13
+    typescript: ^4.5.5
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

## Bug

- [ ] Related issues linked using `closes: #number`

## Feature

- [x] Related issues linked using `closes: #number`
- [x] There is only 1 db migration with no breaking changes.

## Translations

- [ ] `.json` files are formatted: `yarn format`
- [ ] Translations are correct
- [ ] New translation? It's been added to `next.config.js`
