### PR TITLE
:tada: feat: active incidents events

### DIFF
--- a/packages/api/prisma/migrations/20220223131255_/migration.sql
+++ b/packages/api/prisma/migrations/20220223131255_/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "IncidentEvent" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "incidentId" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+
+    CONSTRAINT "IncidentEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "IncidentEvent" ADD CONSTRAINT "IncidentEvent_incidentId_fkey" FOREIGN KEY ("incidentId") REFERENCES "LeoIncident"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -711,22 +711,32 @@ model ImpoundedVehicle {
 }
 
 model LeoIncident {
-  id                   String    @id @default(uuid())
-  caseNumber           Int       @default(autoincrement())
-  description          String?   @db.Text
+  id                   String          @id @default(uuid())
+  caseNumber           Int             @default(autoincrement())
+  description          String?         @db.Text
   descriptionData      Json?
   // when null, it is the dispatcher
-  creator              Officer?  @relation(fields: [creatorId], references: [id])
+  creator              Officer?        @relation(fields: [creatorId], references: [id])
   creatorId            String?
-  officersInvolved     Officer[] @relation("involvedOfficers")
-  firearmsInvolved     Boolean   @default(false)
-  injuriesOrFatalities Boolean   @default(false)
-  arrestsMade          Boolean   @default(false)
-  isActive             Boolean   @default(false)
-  createdAt            DateTime  @default(now())
-  updatedAt            DateTime  @default(now()) @updatedAt
+  officersInvolved     Officer[]       @relation("involvedOfficers")
+  firearmsInvolved     Boolean         @default(false)
+  injuriesOrFatalities Boolean         @default(false)
+  arrestsMade          Boolean         @default(false)
+  isActive             Boolean         @default(false)
+  createdAt            DateTime        @default(now())
+  updatedAt            DateTime        @default(now()) @updatedAt
+  events               IncidentEvent[]
   calls                Call911[]
-  Officer              Officer[] @relation("activeIncident")
+  Officer              Officer[]       @relation("activeIncident")
+}
+
+model IncidentEvent {
+  id          String      @id @default(uuid())
+  createdAt   DateTime    @default(now())
+  updatedAt   DateTime    @default(now()) @updatedAt
+  incident    LeoIncident @relation(fields: [incidentId], references: [id], onDelete: Cascade)
+  incidentId  String
+  description String      @db.Text
 }
 
 model CombinedLeoUnit {

--- a/packages/api/src/controllers/dispatch/DispatchController.ts
+++ b/packages/api/src/controllers/dispatch/DispatchController.ts
@@ -60,6 +60,7 @@ export class DispatchController {
       include: {
         creator: { include: leoProperties },
         officersInvolved: { include: leoProperties },
+        events: true,
       },
     });
 

--- a/packages/api/src/controllers/leo/incidents/IncidentController.ts
+++ b/packages/api/src/controllers/leo/incidents/IncidentController.ts
@@ -27,7 +27,6 @@ export class IncidentController {
       include: {
         creator: { include: leoProperties },
         officersInvolved: { include: leoProperties },
-        events: true,
       },
     });
 

--- a/packages/api/src/controllers/leo/incidents/IncidentController.ts
+++ b/packages/api/src/controllers/leo/incidents/IncidentController.ts
@@ -27,6 +27,7 @@ export class IncidentController {
       include: {
         creator: { include: leoProperties },
         officersInvolved: { include: leoProperties },
+        events: true,
       },
     });
 

--- a/packages/api/src/controllers/leo/incidents/IncidentEventsController.ts
+++ b/packages/api/src/controllers/leo/incidents/IncidentEventsController.ts
@@ -1,0 +1,147 @@
+import { Controller, UseBeforeEach } from "@tsed/common";
+import { Delete, Description, Post, Put } from "@tsed/schema";
+import { NotFound } from "@tsed/exceptions";
+import { BodyParams, PathParams } from "@tsed/platform-params";
+import { prisma } from "lib/prisma";
+import { IsAuth } from "middlewares/index";
+import { leoProperties } from "lib/officer";
+import { CREATE_911_CALL_EVENT } from "@snailycad/schemas";
+import { validateSchema } from "lib/validateSchema";
+import { Socket } from "services/SocketService";
+
+export const incidentInclude = {
+  creator: { include: leoProperties },
+  officersInvolved: { include: leoProperties },
+  events: true,
+};
+
+@Controller("/incidents/events")
+@UseBeforeEach(IsAuth)
+export class IncidentController {
+  private socket: Socket;
+  constructor(socket: Socket) {
+    this.socket = socket;
+  }
+
+  @Post("/:incidentId")
+  async createIncidentEvent(
+    @PathParams("incidentId") incidentId: string,
+    @BodyParams() body: unknown,
+  ) {
+    const data = validateSchema(CREATE_911_CALL_EVENT, body);
+
+    const incident = await prisma.leoIncident.findUnique({
+      where: { id: incidentId },
+      include: incidentInclude,
+    });
+
+    if (!incident || !incident.isActive) {
+      throw new NotFound("incidentNotFound");
+    }
+
+    const event = await prisma.incidentEvent.create({
+      data: {
+        incidentId: incident.id,
+        description: data.description,
+      },
+    });
+
+    this.socket.emitUpdateActiveIncident({
+      ...incident,
+      events: [...incident.events, event],
+    });
+
+    return event;
+  }
+
+  @Put("/:incidentId/:eventId")
+  async updateIncidentEvent(
+    @PathParams("incidentId") incidentId: string,
+    @PathParams("eventId") eventId: string,
+    @BodyParams() body: unknown,
+  ) {
+    const data = validateSchema(CREATE_911_CALL_EVENT, body);
+
+    const incident = await prisma.leoIncident.findUnique({
+      where: { id: incidentId },
+      include: incidentInclude,
+    });
+
+    if (!incident || !incident.isActive) {
+      throw new NotFound("incidentNotFound");
+    }
+
+    const event = await prisma.incidentEvent.findFirst({
+      where: {
+        id: eventId,
+        incidentId,
+      },
+    });
+
+    if (!event) {
+      throw new NotFound("eventNotFound");
+    }
+
+    const updatedEvent = await prisma.incidentEvent.update({
+      where: {
+        id: event.id,
+      },
+      data: {
+        description: data.description,
+      },
+    });
+
+    const updatedEvents = incident.events.map((event) => {
+      if (event.id === updatedEvent.id) {
+        return updatedEvent;
+      }
+      return event;
+    });
+
+    this.socket.emitUpdateActiveIncident({
+      ...incident,
+      events: updatedEvents,
+    });
+
+    return updatedEvent;
+  }
+
+  @Delete("/:incidentId/:eventId")
+  @Description("Delete an incident event by the incident id and event id")
+  async deleteIncidentEvent(
+    @PathParams("incidentId") incidentId: string,
+    @PathParams("eventId") eventId: string,
+  ) {
+    const incident = await prisma.leoIncident.findUnique({
+      where: { id: incidentId },
+      include: incidentInclude,
+    });
+
+    if (!incident || !incident.isActive) {
+      throw new NotFound("incidentNotFound");
+    }
+
+    const event = await prisma.incidentEvent.findFirst({
+      where: {
+        id: eventId,
+        incidentId,
+      },
+    });
+
+    if (!event) {
+      throw new NotFound("eventNotFound");
+    }
+
+    await prisma.incidentEvent.delete({
+      where: {
+        id: event.id,
+      },
+    });
+
+    const updatedEvents = incident.events.filter((v) => v.id !== event.id);
+
+    this.socket.emitUpdateActiveIncident({ ...incident, events: updatedEvents });
+
+    return true;
+  }
+}

--- a/packages/api/src/lib/officer.ts
+++ b/packages/api/src/lib/officer.ts
@@ -26,7 +26,7 @@ export const _leoProperties = {
 
 export const leoProperties = {
   ..._leoProperties,
-  activeIncident: { include: { officersInvolved: { include: _leoProperties } } },
+  activeIncident: { include: { officersInvolved: { include: _leoProperties }, events: true } },
 };
 
 export async function getActiveOfficer(req: Req, user: User, ctx: Context) {

--- a/packages/api/src/services/SocketService.ts
+++ b/packages/api/src/services/SocketService.ts
@@ -2,6 +2,9 @@ import * as SocketIO from "socket.io";
 import { Nsp, SocketService } from "@tsed/socketio";
 import { SocketEvents } from "@snailycad/config";
 import type { LeoIncident, Call911, TowCall, Bolo, Call911Event, TaxiCall } from "@prisma/client";
+import type { IncidentEvent } from "@snailycad/types";
+
+type FullIncident = LeoIncident & { events?: IncidentEvent[] };
 
 @SocketService("/")
 export class Socket {
@@ -16,11 +19,11 @@ export class Socket {
     this.io.sockets.emit(SocketEvents.Create911Call, call);
   }
 
-  emitUpdateActiveIncident(incident: LeoIncident) {
+  emitUpdateActiveIncident(incident: FullIncident) {
     this.io.sockets.emit(SocketEvents.UpdateActiveIncident, incident);
   }
 
-  emitCreateActiveIncident(incident: LeoIncident) {
+  emitCreateActiveIncident(incident: FullIncident) {
     this.io.sockets.emit(SocketEvents.CreateActiveIncident, incident);
   }
 
@@ -118,5 +121,17 @@ export class Socket {
 
   emitActiveDispatchers() {
     this.io.sockets.emit(SocketEvents.UpdateDispatchersState);
+  }
+
+  emitAddIncidentEvent(event: IncidentEvent) {
+    this.io.sockets.emit(SocketEvents.AddIncidentEvent, event);
+  }
+
+  emitUpdateIncidentEvent(event: IncidentEvent) {
+    this.io.sockets.emit(SocketEvents.UpdateIncidentEvent, event);
+  }
+
+  emitDeleteIncidentEvent(event: IncidentEvent) {
+    this.io.sockets.emit(SocketEvents.DeleteIncidentEvent, event);
   }
 }

--- a/packages/api/src/services/SocketService.ts
+++ b/packages/api/src/services/SocketService.ts
@@ -122,16 +122,4 @@ export class Socket {
   emitActiveDispatchers() {
     this.io.sockets.emit(SocketEvents.UpdateDispatchersState);
   }
-
-  emitAddIncidentEvent(event: IncidentEvent) {
-    this.io.sockets.emit(SocketEvents.AddIncidentEvent, event);
-  }
-
-  emitUpdateIncidentEvent(event: IncidentEvent) {
-    this.io.sockets.emit(SocketEvents.UpdateIncidentEvent, event);
-  }
-
-  emitDeleteIncidentEvent(event: IncidentEvent) {
-    this.io.sockets.emit(SocketEvents.DeleteIncidentEvent, event);
-  }
 }

--- a/packages/client/locales/en/leo.json
+++ b/packages/client/locales/en/leo.json
@@ -141,6 +141,7 @@
     "manageIncident": "Manage Incident",
     "radioChannel": "Radio Channel",
     "manageRadioChannel": "Manage Radio Channel",
+    "noIncidentEvents": "This incident does not have any events.",
     "alert_endIncident": "Are you sure you want to end this incident. It can still be viewed by officers.",
     "alert_deleteRecord": "Are you sure you want to delete this record? This action cannot be undone.",
     "alert_deleteOfficer": "Are you sure you want to delete <span>{officer}</span>? This action cannot be undone.",

--- a/packages/client/src/components/dispatch/ActiveIncidents.tsx
+++ b/packages/client/src/components/dispatch/ActiveIncidents.tsx
@@ -11,7 +11,7 @@ import { FullDate } from "components/shared/FullDate";
 import { ModalIds } from "types/ModalIds";
 import { useModal } from "context/ModalContext";
 import { DescriptionModal } from "components/modal/DescriptionModal/DescriptionModal";
-import { ManageIncidentModal } from "components/leo/modals/ManageIncidentModal";
+import { ManageIncidentModal } from "components/leo/incidents/ManageIncidentModal";
 import { useActiveIncidents } from "hooks/realtime/useActiveIncidents";
 import { AlertModal } from "components/modal/AlertModal";
 import useFetch from "lib/useFetch";
@@ -68,7 +68,7 @@ export function ActiveIncidents() {
 
   function handleCreateIncident() {
     openModal(ModalIds.ManageIncident);
-    setTempIncident(undefined);
+    setTempIncident(null);
   }
 
   function involvedOfficers(incident: FullIncident) {

--- a/packages/client/src/components/dispatch/ActiveOfficers.tsx
+++ b/packages/client/src/components/dispatch/ActiveOfficers.tsx
@@ -20,7 +20,7 @@ import { useActiveDispatchers } from "hooks/realtime/useActiveDispatchers";
 import { Table } from "components/shared/Table";
 import { useFeatureEnabled } from "hooks/useFeatureEnabled";
 import type { FullIncident } from "src/pages/officer/incidents";
-import { ManageIncidentModal } from "components/leo/modals/ManageIncidentModal";
+import { ManageIncidentModal } from "components/leo/incidents/ManageIncidentModal";
 import { UnitRadioChannelModal } from "./active-units/UnitRadioChannelModal";
 
 export function ActiveOfficers() {

--- a/packages/client/src/components/dispatch/ActiveOfficers.tsx
+++ b/packages/client/src/components/dispatch/ActiveOfficers.tsx
@@ -22,6 +22,7 @@ import { useFeatureEnabled } from "hooks/useFeatureEnabled";
 import type { FullIncident } from "src/pages/officer/incidents";
 import { ManageIncidentModal } from "components/leo/incidents/ManageIncidentModal";
 import { UnitRadioChannelModal } from "./active-units/UnitRadioChannelModal";
+import { useActiveIncidents } from "hooks/realtime/useActiveIncidents";
 
 export function ActiveOfficers() {
   const { activeOfficers } = useActiveOfficers();
@@ -42,6 +43,20 @@ export function ActiveOfficers() {
 
   const [tempUnit, setTempUnit] = React.useState<ActiveOfficer | CombinedLeoUnit | null>(null);
   const [tempIncident, setTempIncident] = React.useState<FullIncident | null>(null);
+
+  const { activeIncidents, setActiveIncidents } = useActiveIncidents();
+  const foundIncident = activeIncidents.find((v) => v.id === tempIncident?.id);
+
+  // manage state for real-time updates. Yes, this may look like some janky solution,
+  // but meh. Works for now ;).
+  React.useEffect(() => {
+    const existing = activeIncidents.some((v) => v.id === foundIncident?.id);
+
+    if (!existing && foundIncident) {
+      setActiveIncidents([...activeIncidents, foundIncident]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeIncidents, foundIncident]);
 
   function handleEditClick(officer: ActiveOfficer | CombinedLeoUnit) {
     setTempUnit(officer);

--- a/packages/client/src/components/leo/incidents/IncidentEventsArea.tsx
+++ b/packages/client/src/components/leo/incidents/IncidentEventsArea.tsx
@@ -1,34 +1,31 @@
 import * as React from "react";
-import type { Full911Call } from "state/dispatchState";
-import type { FormikHelpers } from "formik";
-import compareDesc from "date-fns/compareDesc";
+import type { IncidentEvent, LeoIncident } from "@snailycad/types";
 import useFetch from "lib/useFetch";
-import { useTranslations } from "use-intl";
-import type { Call911Event } from "@snailycad/types";
-import { EventItem } from "../events/EventItem";
-import { UpdateEventForm } from "../events/UpdateEventForm";
+import { useTranslations } from "next-intl";
+import compareDesc from "date-fns/compareDesc";
+import { EventItem } from "components/modals/events/EventItem";
+import { UpdateEventForm } from "components/modals/events/UpdateEventForm";
+import type { FormikHelpers } from "formik";
 
 interface Props {
-  call: Full911Call;
+  incident: LeoIncident;
   disabled?: boolean;
 }
 
-export function CallEventsArea({ disabled, call }: Props) {
+export function IncidentEventsArea({ disabled, incident }: Props) {
   const { state, execute } = useFetch();
   const common = useTranslations("Common");
-  const t = useTranslations("Calls");
-  const [tempEvent, setTempEvent] = React.useState<Call911Event | null>(null);
+  const t = useTranslations("Leo");
+  const [tempEvent, setTempEvent] = React.useState<IncidentEvent | null>(null);
 
   async function onEventSubmit(values: { description: string }, helpers: FormikHelpers<any>) {
-    if (!call) return;
-
     if (tempEvent) {
-      await execute(`/911-calls/events/${call.id}/${tempEvent.id}`, {
+      await execute(`/incidents/events/${incident.id}/${tempEvent.id}`, {
         method: "PUT",
         data: values,
       });
     } else {
-      await execute(`/911-calls/events/${call.id}`, {
+      await execute(`/incidents/events/${incident.id}`, {
         method: "POST",
         data: values,
       });
@@ -41,12 +38,12 @@ export function CallEventsArea({ disabled, call }: Props) {
     <div className="w-[45rem] ml-3 relative">
       <h4 className="text-xl font-semibold">{common("events")}</h4>
 
-      <ul className="overflow-auto h-[65%]">
-        {(call?.events.length ?? 0) <= 0 ? (
-          <p className="mt-2">{t("noEvents")}</p>
+      <ul className="overflow-auto h-[58%]">
+        {(incident.events?.length ?? 0) <= 0 ? (
+          <p className="mt-2">{t("noIncidentEvents")}</p>
         ) : (
-          call?.events
-            .sort((a, b) => compareDesc(new Date(a.createdAt), new Date(b.createdAt)))
+          incident.events
+            ?.sort((a, b) => compareDesc(new Date(a.createdAt), new Date(b.createdAt)))
             .map((event) => (
               <EventItem
                 disabled={disabled}

--- a/packages/client/src/components/leo/incidents/ManageIncidentModal.tsx
+++ b/packages/client/src/components/leo/incidents/ManageIncidentModal.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { LEO_INCIDENT_SCHEMA } from "@snailycad/schemas";
 import { Button } from "components/Button";
 import { FormField } from "components/form/FormField";
@@ -22,7 +21,6 @@ import type { FullIncident } from "src/pages/officer/incidents";
 import { dataToSlate, Editor } from "components/modal/DescriptionModal/Editor";
 import { IncidentEventsArea } from "./IncidentEventsArea";
 import { classNames } from "lib/classNames";
-import { useActiveIncidents } from "hooks/realtime/useActiveIncidents";
 
 interface Props {
   incident?: FullIncident | null;
@@ -31,16 +29,7 @@ interface Props {
   onUpdate?(oldIncident: FullIncident, incident: FullIncident): void;
 }
 
-export function ManageIncidentModal({
-  onClose,
-  onCreate,
-  onUpdate,
-  incident: providedIncident,
-}: Props) {
-  const { activeIncidents, setActiveIncidents } = useActiveIncidents();
-  const foundIncident = activeIncidents.find((v) => v.id === providedIncident?.id);
-  const incident = foundIncident ?? providedIncident ?? null;
-
+export function ManageIncidentModal({ onClose, onCreate, onUpdate, incident }: Props) {
   const { isOpen, closeModal } = useModal();
   const common = useTranslations("Common");
   const t = useTranslations("Leo");
@@ -48,24 +37,12 @@ export function ManageIncidentModal({
   const { activeOfficer } = useLeoState();
   const router = useRouter();
   const isDispatch = router.pathname.includes("/dispatch");
-  const isLeo = router.pathname === "/officer";
   const isLeoIncidents = router.pathname === "/officer/incidents";
   const creator = isDispatch || !incident?.creator ? null : incident.creator;
   const areEventsReadonly = !isDispatch || isLeoIncidents;
 
   const { state, execute } = useFetch();
   const { allOfficers } = useDispatchState();
-
-  // manage state for real-time updates. Yes, this may look like some janky solution,
-  // but meh. Works for now ;).
-  React.useEffect(() => {
-    const existing = activeIncidents.some((v) => v.id === incident?.id);
-
-    if (!existing && incident && isLeo) {
-      setActiveIncidents([...activeIncidents, incident]);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeIncidents, incident, isLeo]);
 
   function handleClose() {
     closeModal(ModalIds.ManageIncident);

--- a/packages/client/src/components/leo/incidents/ManageIncidentModal.tsx
+++ b/packages/client/src/components/leo/incidents/ManageIncidentModal.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { LEO_INCIDENT_SCHEMA } from "@snailycad/schemas";
 import { Button } from "components/Button";
 import { FormField } from "components/form/FormField";
@@ -36,7 +37,7 @@ export function ManageIncidentModal({
   onUpdate,
   incident: providedIncident,
 }: Props) {
-  const { activeIncidents } = useActiveIncidents();
+  const { activeIncidents, setActiveIncidents } = useActiveIncidents();
   const foundIncident = activeIncidents.find((v) => v.id === providedIncident?.id);
   const incident = foundIncident ?? providedIncident ?? null;
 
@@ -51,6 +52,17 @@ export function ManageIncidentModal({
 
   const { state, execute } = useFetch();
   const { allOfficers } = useDispatchState();
+
+  // manage state for real-time updates. Yes, this may look like some janky solution,
+  // but meh. Works for now ;).
+  React.useEffect(() => {
+    const existing = activeIncidents.some((v) => v.id === incident?.id);
+
+    if (!existing && incident) {
+      setActiveIncidents([...activeIncidents, incident]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeIncidents, incident]);
 
   function handleClose() {
     closeModal(ModalIds.ManageIncident);

--- a/packages/client/src/components/leo/incidents/ManageIncidentModal.tsx
+++ b/packages/client/src/components/leo/incidents/ManageIncidentModal.tsx
@@ -48,7 +48,10 @@ export function ManageIncidentModal({
   const { activeOfficer } = useLeoState();
   const router = useRouter();
   const isDispatch = router.pathname.includes("/dispatch");
+  const isLeo = router.pathname === "/officer";
+  const isLeoIncidents = router.pathname === "/officer/incidents";
   const creator = isDispatch || !incident?.creator ? null : incident.creator;
+  const areEventsReadonly = !isDispatch || isLeoIncidents;
 
   const { state, execute } = useFetch();
   const { allOfficers } = useDispatchState();
@@ -58,11 +61,11 @@ export function ManageIncidentModal({
   React.useEffect(() => {
     const existing = activeIncidents.some((v) => v.id === incident?.id);
 
-    if (!existing && incident) {
+    if (!existing && incident && isLeo) {
       setActiveIncidents([...activeIncidents, incident]);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeIncidents, incident]);
+  }, [activeIncidents, incident, isLeo]);
 
   function handleClose() {
     closeModal(ModalIds.ManageIncident);
@@ -200,7 +203,7 @@ export function ManageIncidentModal({
           )}
         </Formik>
 
-        {incident ? <IncidentEventsArea disabled={false} incident={incident} /> : null}
+        {incident ? <IncidentEventsArea disabled={areEventsReadonly} incident={incident} /> : null}
       </div>
     </Modal>
   );

--- a/packages/client/src/components/modals/events/EventItem.tsx
+++ b/packages/client/src/components/modals/events/EventItem.tsx
@@ -1,0 +1,90 @@
+import * as React from "react";
+import type { Call911Event, IncidentEvent } from "@snailycad/types";
+import { useModal } from "context/ModalContext";
+import { useHoverDirty } from "react-use";
+import useFetch from "lib/useFetch";
+import { useTranslations } from "next-intl";
+import { ModalIds } from "types/ModalIds";
+import { FullDate } from "components/shared/FullDate";
+import { classNames } from "lib/classNames";
+import { Button } from "components/Button";
+import { Pencil, X } from "react-bootstrap-icons";
+import { AlertModal } from "components/modal/AlertModal";
+
+interface EventItemProps<T extends IncidentEvent | Call911Event> {
+  disabled?: boolean;
+  event: T;
+  setTempEvent: React.Dispatch<React.SetStateAction<T | null>>;
+}
+
+export function EventItem<T extends IncidentEvent | Call911Event>({
+  disabled,
+  event,
+  setTempEvent,
+}: EventItemProps<T>) {
+  const { openModal, closeModal } = useModal();
+  const actionsRef = React.useRef<HTMLLIElement>(null);
+  const isHovering = useHoverDirty(actionsRef);
+  const t = useTranslations("Calls");
+  const { execute } = useFetch();
+  const [open, setOpen] = React.useState(false);
+
+  function handleOpen() {
+    setOpen(true);
+    openModal(ModalIds.AlertDeleteCallEvent);
+  }
+
+  function handleClose() {
+    setOpen(false);
+    closeModal(ModalIds.AlertDeleteCallEvent);
+  }
+
+  async function deleteEvent() {
+    if (disabled) return;
+    const parentId = "call911Id" in event ? event.call911Id : event.incidentId;
+    const routeType = "call911Id" in event ? "911-calls" : "incidents";
+
+    await execute(`/${routeType}/events/${parentId}/${event.id}`, {
+      method: "DELETE",
+    });
+
+    setTempEvent(null);
+    handleClose();
+  }
+
+  return (
+    <li ref={actionsRef} className="flex justify-between">
+      <div>
+        <span className="select-none text-gray-800 dark:text-gray-400 mr-1 font-semibold w-[90%]">
+          <FullDate>{event.createdAt}</FullDate>:
+        </span>
+        <span>{event.description}</span>
+      </div>
+
+      {disabled ? null : (
+        <div className={classNames(isHovering ? "flex" : "hidden")}>
+          <Button
+            className="p-0 px-1 mr-2"
+            small
+            variant="cancel"
+            onClick={() => setTempEvent(event)}
+          >
+            <Pencil width={15} />
+          </Button>
+          <Button className="p-0 px-1" small variant="cancel" onClick={handleOpen}>
+            <X width={20} height={20} />
+          </Button>
+        </div>
+      )}
+
+      {open && !disabled ? (
+        <AlertModal
+          description={t("alert_deleteCallEvent")}
+          onDeleteClick={deleteEvent}
+          title={t("deleteCallEvent")}
+          id={ModalIds.AlertDeleteCallEvent}
+        />
+      ) : null}
+    </li>
+  );
+}

--- a/packages/client/src/components/modals/events/UpdateEventForm.tsx
+++ b/packages/client/src/components/modals/events/UpdateEventForm.tsx
@@ -1,0 +1,74 @@
+import * as React from "react";
+import { Form, Formik, FormikHelpers, useFormikContext } from "formik";
+import { FormField } from "components/form/FormField";
+import { Button } from "components/Button";
+import { Loader } from "components/Loader";
+import { Textarea } from "components/form/Textarea";
+import type { Call911Event, IncidentEvent } from "@snailycad/types";
+import { useTranslations } from "next-intl";
+
+interface Props<T extends IncidentEvent | Call911Event> {
+  event: T | null;
+  setEvent: React.Dispatch<React.SetStateAction<T | null>>;
+  onSubmit: (
+    values: { description: string },
+    helpers: FormikHelpers<{ description: string }>,
+  ) => void;
+  state: "loading" | "error" | null;
+}
+
+export function UpdateEventForm<T extends IncidentEvent | Call911Event>({
+  event,
+  state,
+  setEvent,
+  onSubmit,
+}: Props<T>) {
+  const common = useTranslations("Common");
+  const t = useTranslations("Calls");
+
+  return (
+    <Formik onSubmit={onSubmit} initialValues={{ description: event?.description ?? "" }}>
+      {({ handleChange, values, errors }) => (
+        <Form className="absolute bottom-0 w-full">
+          <FormField errorMessage={errors.description} label={common("description")}>
+            <Textarea
+              required
+              name="description"
+              value={values.description}
+              onChange={handleChange}
+            />
+          </FormField>
+
+          <footer className="flex justify-end mt-5">
+            {event ? (
+              <Button variant="cancel" onClick={() => setEvent(null)} type="reset">
+                {common("cancel")}
+              </Button>
+            ) : null}
+            <Button disabled={state === "loading"} className="flex items-center ml-2" type="submit">
+              {state === "loading" ? <Loader className="mr-2 border-red-200" /> : null}
+
+              {event ? common("save") : t("addEvent")}
+            </Button>
+          </footer>
+
+          <AutoForm event={event} />
+        </Form>
+      )}
+    </Formik>
+  );
+}
+
+function AutoForm<T extends IncidentEvent | Call911Event>({ event }: { event: T | null }) {
+  const { setFieldValue } = useFormikContext();
+
+  React.useEffect(() => {
+    if (event !== null) {
+      setFieldValue("description", event.description);
+    } else {
+      setFieldValue("description", "");
+    }
+  }, [event, setFieldValue]);
+
+  return null;
+}

--- a/packages/client/src/pages/officer/incidents.tsx
+++ b/packages/client/src/pages/officer/incidents.tsx
@@ -30,7 +30,7 @@ interface Props {
 }
 
 const ManageIncidentModal = dynamic(async () => {
-  return (await import("components/leo/modals/ManageIncidentModal")).ManageIncidentModal;
+  return (await import("components/leo/incidents/ManageIncidentModal")).ManageIncidentModal;
 });
 
 const AlertModal = dynamic(async () => {

--- a/packages/client/src/pages/officer/incidents.tsx
+++ b/packages/client/src/pages/officer/incidents.tsx
@@ -226,7 +226,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, locale }) =>
       activeOfficer,
       officers,
       messages: {
-        ...(await getTranslations(["leo", "common"], locale)),
+        ...(await getTranslations(["leo", "calls", "common"], locale)),
       },
     },
   };

--- a/packages/config/src/socket-events.ts
+++ b/packages/config/src/socket-events.ts
@@ -28,6 +28,10 @@ export enum SocketEvents {
   UpdateCallEvent = "UPDATE_CALL_EVENT",
   DeleteCallEvent = "DELETE_CALL_EVENT",
 
+  AddIncidentEvent = "ADD_INCIDENT_EVENT",
+  UpdateIncidentEvent = "UPDATE_INCIDENT_EVENT",
+  DeleteIncidentEvent = "DELETE_INCIDENT_EVENT",
+
   Signal100 = "SIGNAL_100",
 
   PANIC_BUTTON_ON = "PANIC_BUTTON_ON",

--- a/packages/config/src/socket-events.ts
+++ b/packages/config/src/socket-events.ts
@@ -28,10 +28,6 @@ export enum SocketEvents {
   UpdateCallEvent = "UPDATE_CALL_EVENT",
   DeleteCallEvent = "DELETE_CALL_EVENT",
 
-  AddIncidentEvent = "ADD_INCIDENT_EVENT",
-  UpdateIncidentEvent = "UPDATE_INCIDENT_EVENT",
-  DeleteIncidentEvent = "DELETE_INCIDENT_EVENT",
-
   Signal100 = "SIGNAL_100",
 
   PANIC_BUTTON_ON = "PANIC_BUTTON_ON",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -641,6 +641,19 @@ export interface LeoIncident {
   createdAt: Date;
   updatedAt: Date;
   isActive: boolean | null;
+  events?: IncidentEvent[];
+}
+
+/**
+ * Model IncidentEvent
+ *
+ */
+export interface IncidentEvent {
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+  incidentId: string;
+  description: string;
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

## Bug

- [ ] Related issues linked using `closes: #number`

## Feature

- [x] Related issues linked using closes: #449 
- [x] There is only 1 db migration with no breaking changes.

## Translations

- [ ] `.json` files are formatted: `yarn format`
- [ ] Translations are correct
- [ ] New translation? It's been added to `next.config.js`
