### PR TITLE
:tada: feat: inform if call is created via dispatch

### DIFF
--- a/packages/api/prisma/migrations/20220301110033_call_via_dispatch/migration.sql
+++ b/packages/api/prisma/migrations/20220301110033_call_via_dispatch/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Call911" ADD COLUMN     "viaDispatch" BOOLEAN DEFAULT false;

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -809,6 +809,7 @@ model Call911 {
   ended           Boolean?          @default(false)
   situationCode   StatusValue?      @relation(fields: [situationCodeId], references: [id])
   situationCodeId String?
+  viaDispatch     Boolean?          @default(false)
   divisions       DivisionValue[]
   departments     DepartmentValue[]
   events          Call911Event[]

--- a/packages/api/src/controllers/dispatch/911-calls/Calls911Controller.ts
+++ b/packages/api/src/controllers/dispatch/911-calls/Calls911Controller.ts
@@ -1,7 +1,7 @@
 import { Controller } from "@tsed/di";
 import { Delete, Get, Post, Put } from "@tsed/schema";
 import { CREATE_911_CALL, LINK_INCIDENT_TO_CALL } from "@snailycad/schemas";
-import { BodyParams, Context, PathParams, QueryParams } from "@tsed/platform-params";
+import { HeaderParams, BodyParams, Context, PathParams, QueryParams } from "@tsed/platform-params";
 import { BadRequest, NotFound } from "@tsed/exceptions";
 import { prisma } from "lib/prisma";
 import { Socket } from "services/SocketService";
@@ -66,8 +66,10 @@ export class Calls911Controller {
     @BodyParams() body: unknown,
     @Context("user") user: User,
     @Context("cad") cad: cad,
+    @HeaderParams("is-from-dispatch") isFromDispatchHeader: string | undefined,
   ) {
     const data = validateSchema(CREATE_911_CALL, body);
+    const isFromDispatch = isFromDispatchHeader === "true" && user.isDispatch;
 
     const call = await prisma.call911.create({
       data: {
@@ -78,6 +80,7 @@ export class Calls911Controller {
         name: data.name,
         userId: user.id || undefined,
         situationCodeId: data.situationCode ?? null,
+        viaDispatch: isFromDispatch,
       },
       include: callInclude,
     });

--- a/packages/client/src/components/leo/ActiveCalls.tsx
+++ b/packages/client/src/components/leo/ActiveCalls.tsx
@@ -37,6 +37,7 @@ function ActiveCallsInner() {
 
   const { calls, setCalls } = useDispatchState();
   const t = useTranslations("Calls");
+  const leo = useTranslations("Leo");
   const common = useTranslations("Common");
   const { user } = useAuth();
   const router = useRouter();
@@ -138,7 +139,6 @@ function ActiveCallsInner() {
     <div className="overflow-hidden rounded-md card">
       <header className="flex items-center justify-between p-2 px-4 bg-gray-300/50 dark:bg-gray-3">
         <h3 className="text-xl font-semibold">{t("active911Calls")}</h3>
-
         <div>
           <Button
             variant="cancel"
@@ -170,7 +170,7 @@ function ActiveCallsInner() {
                   rowProps: {
                     className: isUnitAssigned ? "bg-gray-200 dark:bg-[#333639]" : undefined,
                   },
-                  name: call.name,
+                  name: `${call.name} ${call.viaDispatch ? `(${leo("dispatch")})` : ""}`,
                   location: call.location,
                   description:
                     call.description && !call.descriptionData ? (

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -704,6 +704,7 @@ export interface Call911 {
   situationCode: StatusValue | null;
   departments?: DepartmentValue[];
   divisions?: DivisionValue[];
+  viaDispatch: boolean | null;
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

## Bug

- [ ] Related issues linked using `closes: #number`

## Feature

- [x] Related issues linked using closes #485 
- [x] There is only 1 db migration with no breaking changes.

## Translations

- [ ] `.json` files are formatted: `yarn format`
- [ ] Translations are correct
- [ ] New translation? It's been added to `next.config.js`
