### PR TITLE
:tada: feat: allow warning and warning not applicable at same time

### DIFF
--- a/packages/api/src/lib/records/penal-code.ts
+++ b/packages/api/src/lib/records/penal-code.ts
@@ -9,7 +9,7 @@ export async function upsertWarningApplicable(
   body: z.infer<typeof PENAL_CODE_SCHEMA>,
   penalCode?: PickWarningPenalCode,
 ): Promise<PickWarningPenalCode> {
-  let idData: PickWarningPenalCode = { warningApplicableId: null, warningNotApplicableId: null };
+  const idData: PickWarningPenalCode = { warningApplicableId: null, warningNotApplicableId: null };
 
   if (body.warningApplicable) {
     const fines = parsePenalCodeValues(body.warningFines);

--- a/packages/client/src/components/admin/values/penal-codes/ManagePenalCode.tsx
+++ b/packages/client/src/components/admin/values/penal-codes/ManagePenalCode.tsx
@@ -37,9 +37,11 @@ export function ManagePenalCode({ onCreate, onUpdate, groups, type, penalCode }:
       descriptionData: values.descriptionData,
       title: values.title,
       warningApplicable: values.warningApplicable,
-      fines: values.warningApplicable ? values.fines1.values : values.fines2.values,
-      prisonTerm: values.warningApplicable ? null : values.prisonTerm.values,
-      bail: values.warningApplicable ? null : values.bail.values,
+      warningNotApplicable: values.warningNotApplicable,
+      warningFines: values.warningApplicable ? values.fines1.values : null,
+      warningNotFines: values.warningNotApplicable ? values.fines2.values : null,
+      prisonTerm: values.warningNotApplicable ? values.prisonTerm.values : null,
+      bail: values.warningNotApplicable ? values.bail.values : null,
       groupId: values.group === "ungrouped" || !values.group ? null : values.group,
     };
 
@@ -71,7 +73,8 @@ export function ManagePenalCode({ onCreate, onUpdate, groups, type, penalCode }:
     description: penalCode?.description ?? "",
     descriptionData: dataToSlate(penalCode),
     group: penalCode?.groupId ?? "",
-    warningApplicable: !!penalCode?.warningApplicable,
+    warningApplicable: !!penalCode?.warningApplicableId,
+    warningNotApplicable: !!penalCode?.warningNotApplicableId,
     fines1: {
       enabled: (penalCode?.warningApplicable?.fines.length ?? 0) > 0,
       values: penalCode?.warningApplicable?.fines ?? [],
@@ -130,8 +133,8 @@ export function ManagePenalCode({ onCreate, onUpdate, groups, type, penalCode }:
                 <FormField checkbox label="Warning applicable">
                   <Input
                     checked={values.warningApplicable}
-                    onChange={() => setFieldValue("warningApplicable", true)}
-                    type="radio"
+                    onChange={() => setFieldValue("warningApplicable", !values.warningApplicable)}
+                    type="checkbox"
                   />
                 </FormField>
 
@@ -143,9 +146,11 @@ export function ManagePenalCode({ onCreate, onUpdate, groups, type, penalCode }:
               <div className="ml-2.5">
                 <FormField checkbox label="Warning not applicable">
                   <Input
-                    checked={!values.warningApplicable}
-                    onChange={() => setFieldValue("warningApplicable", false)}
-                    type="radio"
+                    checked={values.warningNotApplicable}
+                    onChange={() =>
+                      setFieldValue("warningNotApplicable", !values.warningNotApplicable)
+                    }
+                    type="checkbox"
                   />
                 </FormField>
 
@@ -180,7 +185,7 @@ export function ManagePenalCode({ onCreate, onUpdate, groups, type, penalCode }:
 const FieldsRow = ({ keyValue }: { keyValue: `fines${number}` | "prisonTerm" | "bail" }) => {
   const { values, handleChange, setFieldValue } = useFormikContext<any>();
 
-  const disabled = keyValue === "fines1" ? !values.warningApplicable : values.warningApplicable;
+  const disabled = keyValue === "fines1" ? !values.warningApplicable : !values.warningNotApplicable;
   const fieldDisabled = !values[keyValue].enabled;
   const isDisabled = disabled || fieldDisabled;
 

--- a/packages/schemas/src/admin/values/import.ts
+++ b/packages/schemas/src/admin/values/import.ts
@@ -86,7 +86,9 @@ export const PENAL_CODE_SCHEMA = z.object({
   description: z.string().nullable().optional(),
   groupId: z.string().nullable().optional(),
   warningApplicable: z.boolean().optional(),
-  fines: z.any().nullable().optional(),
+  warningNotApplicable: z.boolean().optional(),
+  warningFines: z.any().nullable().optional(),
+  warningNotFines: z.any().nullable().optional(),
   bail: z.any().nullable().optional(),
   prisonTerm: z.any().nullable().optional(),
 });


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

⚠️ needs further testing. **docs must be updated**

## Bug

- [ ] Related issues linked using `closes: #number`

## Feature

- [x] Related issues linked using closes #492 
- [x] There is only 1 db migration with no breaking changes.

## Translations

- [ ] `.json` files are formatted: `yarn format`
- [ ] Translations are correct
- [ ] New translation? It's been added to `next.config.js`
