### PR TITLE
:tada: feat: allow export of admin values

### DIFF
--- a/packages/client/src/components/admin/values/import/OptionsDropdown.tsx
+++ b/packages/client/src/components/admin/values/import/OptionsDropdown.tsx
@@ -5,19 +5,25 @@ import { ModalIds } from "types/ModalIds";
 import { useModal } from "context/ModalContext";
 import { useDownload } from "@casper124578/useful";
 import { Dropdown } from "components/Dropdown";
-import type { PenalCode } from "@snailycad/types";
-import type { AnyValue } from "@snailycad/utils";
+import { PenalCode, ValueType } from "@snailycad/types";
+import { AnyValue, isDivisionValue, isStatusValue } from "@snailycad/utils";
+import format from "date-fns/format";
 
-export function OptionsDropdown({ values }: { values: (AnyValue | PenalCode)[] }) {
+interface Props {
+  type: ValueType;
+  values: (AnyValue | PenalCode)[];
+}
+
+export function OptionsDropdown({ type, values }: Props) {
   const t = useTranslations("Values");
   const { openModal } = useModal();
   const download = useDownload();
 
   function handleExport() {
+    const date = format(Date.now(), "yyyy-MM-dd-hh-ss-mm");
     download({
-      filename: `products_${Date.now()}.json`,
-      // todo: remove extra properties such as id
-      data: JSON.stringify(values, null, 4),
+      filename: `${type.toLowerCase()}_${date}.json`,
+      data: JSON.stringify(omitUnnecessaryProperties([...values]), null, 4),
     });
   }
 
@@ -35,9 +41,36 @@ export function OptionsDropdown({ values }: { values: (AnyValue | PenalCode)[] }
       <Dropdown.Item onClick={() => openModal(ModalIds.ImportValues)}>
         {t("importValues")}
       </Dropdown.Item>
-      <Dropdown.Item onClick={handleExport} disabled>
+      <Dropdown.Item
+        disabled={values.length <= 0 || type === ValueType.PENAL_CODE}
+        onClick={handleExport}
+      >
         {t("exportValues")}
       </Dropdown.Item>
     </Dropdown>
   );
+}
+
+function omitUnnecessaryProperties(values: readonly any[]) {
+  return values.map((v) => {
+    delete v.id;
+
+    if ("createdAt" in v) {
+      delete v.createdAt;
+      delete v.updatedAt;
+      delete v.type;
+    }
+
+    if (isStatusValue(v)) {
+      (v.departments as any) = v.departments?.map((v) => v.id) ?? [];
+    }
+
+    if (isDivisionValue(v)) {
+      delete (v as any).department;
+    }
+
+    const value = { value: v.value.value, position: v.value.position };
+    delete v.valueId;
+    return { ...v, ...value };
+  });
 }

--- a/packages/client/src/pages/admin/values/[path].tsx
+++ b/packages/client/src/pages/admin/values/[path].tsx
@@ -180,7 +180,7 @@ export default function ValuePath({ pathValues: { type, values: data } }: Props)
 
         <div className="flex gap-2">
           <Button onClick={() => openModal(ModalIds.ManageValue)}>{typeT("ADD")}</Button>
-          <OptionsDropdown values={values} />
+          <OptionsDropdown type={type} values={values} />
         </div>
       </header>
 

--- a/packages/client/src/pages/admin/values/penal-code.tsx
+++ b/packages/client/src/pages/admin/values/penal-code.tsx
@@ -189,7 +189,7 @@ export default function ValuePath({ values: { type, groups: groupData, values: d
           <Button onClick={() => openModal(ModalIds.ManagePenalCodeGroup)}>
             {t("addPenalCodeGroup")}
           </Button>
-          <OptionsDropdown values={values} />
+          <OptionsDropdown type={type} values={values} />
         </div>
       </header>
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

## Bug

- [ ] Related issues linked using `closes: #number`

## Feature

- [x] Related issues linked using closes: #523 
- [x] There is only 1 db migration with no breaking changes.

## Translations

- [ ] `.json` files are formatted: `yarn format`
- [ ] Translations are correct
- [ ] New translation? It's been added to `next.config.js`
