### PR TITLE
🎉 feat: end active calls & incidents after timeout (optional)

### DIFF
--- a/packages/api/prisma/migrations/20220413055643_/migration.sql
+++ b/packages/api/prisma/migrations/20220413055643_/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "MiscCadSettings" ADD COLUMN     "inactivityTimeout" INTEGER;

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -73,6 +73,7 @@ model MiscCadSettings {
   authScreenHeaderImageId   String?
   call911WebhookId          String?
   statusesWebhookId         String?
+  inactivityTimeout         Int?
 
   cad cad[]
 }

--- a/packages/api/src/controllers/admin/manage/cad-settings/CadSettings.ts
+++ b/packages/api/src/controllers/admin/manage/cad-settings/CadSettings.ts
@@ -125,6 +125,7 @@ export class ManageCitizensController {
         maxDepartmentsEachPerUser: data.maxDepartmentsEachPerUser,
         maxAssignmentsToCalls: data.maxAssignmentsToCalls,
         maxAssignmentsToIncidents: data.maxAssignmentsToIncidents,
+        inactivityTimeout: data.inactivityTimeout || null,
       },
     });
 

--- a/packages/api/src/lib/leo/utils.ts
+++ b/packages/api/src/lib/leo/utils.ts
@@ -30,3 +30,20 @@ export async function validateMaxDepartmentsEachPerUser({
     throw new ExtendedBadRequest({ department: "maxDepartmentsReachedPerUser" });
   }
 }
+
+export function getInactivityFilter(cad: { miscCadSettings: MiscCadSettings | null }) {
+  const inactivityTimeout = cad.miscCadSettings?.inactivityTimeout ?? null;
+
+  if (!inactivityTimeout) {
+    return null;
+  }
+
+  const milliseconds = inactivityTimeout * (1000 * 60);
+  const updatedAt = new Date(new Date().getTime() - milliseconds);
+
+  const filter = {
+    updatedAt: { gte: updatedAt },
+  };
+
+  return { filter, updatedAt };
+}

--- a/packages/client/src/components/admin/manage/cad-settings/MiscFeatures.tsx
+++ b/packages/client/src/components/admin/manage/cad-settings/MiscFeatures.tsx
@@ -136,9 +136,10 @@ export function MiscFeatures() {
             </SettingsFormField>
 
             <SettingsFormField
+              optional
               action="short-input"
               label="Inactivity Timeout"
-              description="Calls/incidents that have not been updated after this timeout will be automatically ended. The format must be in minutes."
+              description="Calls/incidents that have not been updated after this timeout will be automatically ended. The format must be in minutes. (Default: none)"
               errorMessage={errors.inactivityTimeout}
             >
               <Input

--- a/packages/client/src/components/admin/manage/cad-settings/MiscFeatures.tsx
+++ b/packages/client/src/components/admin/manage/cad-settings/MiscFeatures.tsx
@@ -97,6 +97,7 @@ export function MiscFeatures() {
     callsignTemplate: miscSettings.callsignTemplate ?? "",
     pairedUnitTemplate: miscSettings.pairedUnitTemplate ?? "",
     liveMapURL: miscSettings.liveMapURL ?? "",
+    inactivityTimeout: miscSettings.inactivityTimeout ?? "",
   };
 
   return (
@@ -131,6 +132,21 @@ export function MiscFeatures() {
                 value={values.liveMapURL}
                 onChange={handleChange}
                 placeholder="ws://my-host:my-port"
+              />
+            </SettingsFormField>
+
+            <SettingsFormField
+              action="short-input"
+              label="Inactivity Timeout"
+              description="Calls/incidents that have not been updated after this timeout will be automatically ended. The format must be in minutes."
+              errorMessage={errors.inactivityTimeout}
+            >
+              <Input
+                type="number"
+                name="inactivityTimeout"
+                value={values.inactivityTimeout}
+                onChange={handleChange}
+                placeholder="120"
               />
             </SettingsFormField>
 

--- a/packages/schemas/src/admin/index.ts
+++ b/packages/schemas/src/admin/index.ts
@@ -31,6 +31,7 @@ export const CAD_MISC_SETTINGS_SCHEMA = z.object({
   maxOfficersPerUser: z.number().nullable(),
   authScreenBgImageId: z.any().or(z.string()).optional(),
   authScreenHeaderImageId: z.any().or(z.string()).optional(),
+  inactivityTimeout: z.number().optional().nullable(),
 });
 
 export const DISCORD_SETTINGS_SCHEMA = z.object({

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -19,7 +19,6 @@ export interface cad {
   taxiWhitelisted: boolean;
   businessWhitelisted: boolean;
   maxPlateLength: number;
-  liveMapSocketURl: string | null;
   logoId: string | null;
   registrationCode: string | null;
   features: CadFeature[];
@@ -72,6 +71,7 @@ export interface MiscCadSettings {
   authScreenHeaderImageId: string | null;
   statusesWebhookId: string | null;
   call911WebhookId: string | null;
+  inactivityTimeout: number | null;
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

## Bug

- [ ] Related issues linked using `closes: #number`

## Feature

- [x] Related issues linked using closes #610 
- [x] There is only 1 db migration with no breaking changes.

## Translations

- [ ] `.json` files are formatted: `yarn format`
- [ ] Translations are correct
- [ ] New translation? It's been added to `next.config.js`
