### PR TITLE
<g-emoji class="g-emoji" alias="tada" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f389.png"><g-emoji class="g-emoji" alias="tada" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f389.png">🎉</g-emoji></g-emoji> feat: add officer rank image

### DIFF
--- a/packages/api/src/controllers/admin/values/Import.ts
+++ b/packages/api/src/controllers/admin/values/Import.ts
@@ -312,6 +312,8 @@ export const typeHandlers = {
   GENERIC: async (body: unknown, type: ValueType, id?: string): Promise<Value[]> => {
     const data = validateSchema(BASE_ARR, body);
 
+    console.log({ data });
+
     return prisma.$transaction(
       data.map((item) => {
         const data = {
@@ -321,6 +323,10 @@ export const typeHandlers = {
             value: { set: item.value },
             licenseType:
               type === ValueType.LICENSE ? (item.licenseType as ValueLicenseType) : undefined,
+            officerRankImageId:
+              type === ValueType.OFFICER_RANK
+                ? validateImgurURL(item.officerRankImageId)
+                : undefined,
           },
           create: {
             isDefault: type === ValueType.LICENSE ? item.isDefault ?? false : false,
@@ -328,6 +334,10 @@ export const typeHandlers = {
             value: item.value,
             licenseType:
               type === ValueType.LICENSE ? (item.licenseType as ValueLicenseType) : undefined,
+            officerRankImageId:
+              type === ValueType.OFFICER_RANK
+                ? validateImgurURL(item.officerRankImageId)
+                : undefined,
           },
         };
 

--- a/packages/client/src/components/admin/manage/units/AllUnitsTab.tsx
+++ b/packages/client/src/components/admin/manage/units/AllUnitsTab.tsx
@@ -18,6 +18,7 @@ import { classNames } from "lib/classNames";
 import { useModal } from "state/modalState";
 import { ModalIds } from "types/ModalIds";
 import { AlertModal } from "components/modal/AlertModal";
+import { OfficerRank } from "components/leo/OfficerRank";
 
 interface Props {
   units: Unit[];
@@ -133,7 +134,7 @@ export function AllUnitsTab({ search, units }: Props) {
                 <Status state={departmentStatus}>{departmentStatusFormatted}</Status>
               ),
               division: formatUnitDivisions(unit),
-              rank: unit.rank?.value ?? common("none"),
+              rank: <OfficerRank unit={unit} />,
               status: unit.status?.value.value ?? common("none"),
               suspended: common(yesOrNoText(unit.suspended)),
               actions: (

--- a/packages/client/src/components/admin/values/ManageValueModal.tsx
+++ b/packages/client/src/components/admin/values/ManageValueModal.tsx
@@ -43,7 +43,7 @@ import {
   AnyValue,
 } from "@snailycad/utils/typeguards";
 import { QualificationFields } from "./manage-modal/QualificationFields";
-import { validateFile } from "components/form/inputs/ImageSelectInput";
+import { ImageSelectInput, validateFile } from "components/form/inputs/ImageSelectInput";
 
 interface Props {
   type: ValueType;
@@ -110,7 +110,7 @@ export function ManageValueModal({ onCreate, onUpdate, clType: dlType, type, val
 
       if (json?.id) {
         closeModal(ModalIds.ManageValue);
-        await handleQualificationImageUpload(value.id, helpers);
+        await handleValueImageUpload(type.toLowerCase(), value.id, helpers);
         onUpdate(value, json);
       }
     } else {
@@ -121,14 +121,14 @@ export function ManageValueModal({ onCreate, onUpdate, clType: dlType, type, val
       });
 
       if (json?.id) {
-        await handleQualificationImageUpload(json.id, helpers);
+        await handleValueImageUpload(type.toLowerCase(), json.id, helpers);
         closeModal(ModalIds.ManageValue);
         onCreate(json);
       }
     }
   }
 
-  async function handleQualificationImageUpload(id: string, helpers: FormikHelpers<any>) {
+  async function handleValueImageUpload(type: string, id: string, helpers: FormikHelpers<any>) {
     const fd = new FormData();
     const validatedImage = validateFile(image, helpers);
 
@@ -139,7 +139,7 @@ export function ManageValueModal({ onCreate, onUpdate, clType: dlType, type, val
     }
 
     if (validatedImage && typeof validatedImage === "object") {
-      await execute(`/admin/values/qualification/image/${id}`, {
+      await execute(`/admin/values/${type}/image/${id}`, {
         method: "POST",
         data: fd,
         helpers,
@@ -179,6 +179,7 @@ export function ManageValueModal({ onCreate, onUpdate, clType: dlType, type, val
 
     licenseType: value && isBaseValue(value) ? value.licenseType : null,
     isDefault: value && isBaseValue(value) ? value.isDefault : undefined,
+    officerRankImageId: "",
 
     showPicker: false,
     image: "",
@@ -259,6 +260,10 @@ export function ManageValueModal({ onCreate, onUpdate, clType: dlType, type, val
               <FormField optional label="Game Hash">
                 <Input name="hash" onChange={handleChange} value={values.hash} />
               </FormField>
+            ) : null}
+
+            {type === ValueType.OFFICER_RANK ? (
+              <ImageSelectInput valueKey="officerRankImageId" image={image} setImage={setImage} />
             ) : null}
 
             {type === "CODES_10" ? <StatusValueFields /> : null}

--- a/packages/client/src/components/leo/OfficerRank.tsx
+++ b/packages/client/src/components/leo/OfficerRank.tsx
@@ -1,0 +1,23 @@
+import type { EmsFdDeputy, Officer } from "@snailycad/types";
+import { isUnitOfficer } from "@snailycad/utils";
+import { useImageUrl } from "hooks/useImageUrl";
+import { useTranslations } from "next-intl";
+
+export function OfficerRank({ unit }: { unit: Officer | EmsFdDeputy }) {
+  const common = useTranslations("Common");
+  const rank = unit.rank?.value ?? common("none");
+  const { makeImageUrl } = useImageUrl();
+  const imgUrl = makeImageUrl("values", unit.rank?.officerRankImageId ?? null);
+
+  if (!isUnitOfficer(unit)) {
+    // eslint-disable-next-line react/jsx-no-useless-fragment
+    return <>{rank}</>;
+  }
+
+  return (
+    <span className="flex flex-row gap-2 pr-4">
+      <img src={imgUrl} width={25} height={25} className="object-cover" />
+      {rank}
+    </span>
+  );
+}

--- a/packages/client/src/lib/admin/values.tsx
+++ b/packages/client/src/lib/admin/values.tsx
@@ -123,6 +123,17 @@ export function useTableDataOfType(type: ValueType) {
           departments: v.departments.map((v) => v.value.value).join(", "),
         };
       }
+      case ValueType.OFFICER_RANK: {
+        const imgUrl = makeImageUrl("values", value.officerRankImageId);
+
+        return {
+          image: imgUrl ? (
+            <img src={imgUrl} width={50} height={50} className="object-cover" />
+          ) : (
+            "—"
+          ),
+        };
+      }
       default: {
         return {};
       }
@@ -176,6 +187,9 @@ export function useTableHeadersOfType(type: ValueType) {
         { Header: common("image"), accessor: "image" },
         { Header: t("departments"), accessor: "departments" },
       ];
+    }
+    case ValueType.OFFICER_RANK: {
+      return [{ Header: common("image"), accessor: "image" }];
     }
     default: {
       return [];

--- a/packages/client/src/pages/ems-fd/my-deputies.tsx
+++ b/packages/client/src/pages/ems-fd/my-deputies.tsx
@@ -17,6 +17,7 @@ import { Title } from "components/shared/Title";
 import type { EmsFdDeputy } from "@snailycad/types";
 import { Permissions } from "@snailycad/permissions";
 import { useFeatureEnabled } from "hooks/useFeatureEnabled";
+import { OfficerRank } from "components/leo/OfficerRank";
 
 const AlertModal = dynamic(async () => (await import("components/modal/AlertModal")).AlertModal);
 const ManageDeputyModal = dynamic(
@@ -92,7 +93,7 @@ export default function MyDeputies({ deputies: data }: Props) {
             badgeNumber: deputy.badgeNumber,
             department: deputy.department.value.value,
             division: deputy.division.value.value,
-            rank: deputy.rank?.value ?? common("none"),
+            rank: <OfficerRank unit={deputy} />,
             actions: (
               <>
                 <Button small onClick={() => handleEditClick(deputy)} variant="success">

--- a/packages/client/src/pages/officer/my-officers.tsx
+++ b/packages/client/src/pages/officer/my-officers.tsx
@@ -20,6 +20,7 @@ import { Info } from "react-bootstrap-icons";
 import { Status } from "components/shared/Status";
 import { Permissions } from "@snailycad/permissions";
 import { useFeatureEnabled } from "hooks/useFeatureEnabled";
+import { OfficerRank } from "components/leo/OfficerRank";
 
 const AlertModal = dynamic(async () => (await import("components/modal/AlertModal")).AlertModal);
 const ManageOfficerModal = dynamic(
@@ -128,7 +129,7 @@ export default function MyOfficers({ officers: data }: Props) {
                 </span>
               ),
               division: formatUnitDivisions(officer),
-              rank: officer.rank?.value ?? common("none"),
+              rank: <OfficerRank unit={officer} />,
               actions: (
                 <>
                   <Button small onClick={() => handleEditClick(officer)} variant="success">

--- a/packages/schemas/src/admin/values/import.ts
+++ b/packages/schemas/src/admin/values/import.ts
@@ -5,6 +5,7 @@ export const BASE_VALUE_SCHEMA = z.object({
   value: z.string().min(1).max(255),
   licenseType: z.string().regex(LICENSE_TYPE_REGEX).nullable().optional(),
   isDefault: z.boolean().nullable().optional(),
+  officerRankImageId: z.any().nullable().optional(),
 });
 export const BASE_ARR = z.array(BASE_VALUE_SCHEMA).min(1);
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -312,6 +312,7 @@ export interface Value<Type extends ValueType> {
   updatedAt: Date;
   position: number | null;
   licenseType: ValueLicenseType | null;
+  officerRankImageId: string | null;
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

## Bug

- [ ] Related issues linked using `closes: #number`

## Feature

- [x] Related issues linked using closes: #677 
- [x] There is only 1 db migration with no breaking changes.

## Translations

- [ ] `.json` files are formatted: `yarn format`
- [ ] Translations are correct
- [ ] New translation? It's been added to `next.config.js`
