### PR TITLE
:tada: feat: drag-drop for active incident units involved

### DIFF
--- a/packages/api/src/controllers/leo/incidents/IncidentController.ts
+++ b/packages/api/src/controllers/leo/incidents/IncidentController.ts
@@ -112,6 +112,93 @@ export class IncidentController {
     return corrected;
   }
 
+  @Post("/:type/:incidentId")
+  @UsePermissions({
+    fallback: (u) => u.isDispatch || u.isLeo || u.isEmsFd,
+    permissions: [Permissions.Dispatch, Permissions.Leo, Permissions.EmsFd],
+  })
+  async assignToIncident(
+    @PathParams("type") callType: "assign" | "unassign",
+    @PathParams("incidentId") incidentId: string,
+    @BodyParams() body: any,
+  ) {
+    const { unit: rawUnit } = body;
+
+    if (!rawUnit) {
+      throw new BadRequest("unitIsRequired");
+    }
+
+    const { unit, type } = await findUnit(rawUnit);
+    if (!unit) {
+      throw new NotFound("unitNotFound");
+    }
+
+    const incident = await prisma.leoIncident.findUnique({
+      where: { id: incidentId },
+    });
+
+    if (!incident) {
+      throw new NotFound("incidentNotFound");
+    }
+
+    const types = {
+      combined: "combinedLeoId",
+      leo: "officerId",
+      "ems-fd": "emsFdDeputyId",
+    };
+
+    const existing = await prisma.incidentInvolvedUnit.findFirst({
+      where: {
+        incidentId,
+        [types[type]]: unit.id,
+      },
+    });
+
+    if (callType === "assign") {
+      if (existing) {
+        throw new BadRequest("alreadyAssignedToCall");
+      }
+
+      await prisma.incidentInvolvedUnit.create({
+        data: {
+          incidentId,
+          [types[type]]: unit.id,
+        },
+      });
+    } else {
+      if (!existing) {
+        throw new BadRequest("notAssignedToCall");
+      }
+
+      await prisma.incidentInvolvedUnit.delete({
+        where: { id: existing.id },
+      });
+    }
+
+    if (type === "leo") {
+      await prisma.officer.update({
+        where: { id: unit.id },
+        data: { activeIncidentId: callType === "assign" ? incidentId : null },
+      });
+
+      await Promise.all([
+        this.socket.emitUpdateOfficerStatus(),
+        this.socket.emitUpdateDeputyStatus(),
+      ]);
+    }
+
+    const updated = await prisma.leoIncident.findUnique({
+      where: {
+        id: incident.id,
+      },
+      include: incidentInclude,
+    });
+
+    this.socket.emitUpdate911Call(officerOrDeputyToUnit(updated));
+
+    return officerOrDeputyToUnit(updated);
+  }
+
   @UseBefore(ActiveOfficer)
   @Put("/:id")
   @UsePermissions({

--- a/packages/client/locales/en/leo.json
+++ b/packages/client/locales/en/leo.json
@@ -212,6 +212,7 @@
     "manageNote": "Manage Note",
     "text": "Text",
     "deleteNote": "Delete note",
+    "dropToUnassignFromIncident": "Drop to unassign from active incident",
     "alert_deleteNote": "Are you sure you want to delete this note? This action cannot be undone.",
     "alert_deleteQualification": "Are you sure you want to delete this qualification? This action cannot be undone.",
     "alert_deleteDLExam": "Are you sure you want to delete this driver's license exam? This action cannot be undone.",

--- a/packages/client/src/components/dispatch/ActiveDeputies.tsx
+++ b/packages/client/src/components/dispatch/ActiveDeputies.tsx
@@ -121,7 +121,7 @@ export function ActiveDeputies() {
                         <Draggable
                           canDrag={hasActiveDispatchers && isDispatch}
                           item={deputy}
-                          type={DndActions.MoveUnitTo911Call}
+                          type={DndActions.MoveUnitTo911CallOrIncident}
                         >
                           {({ isDragging }) => (
                             <ActiveUnitsQualificationsCard canBeOpened={!isDragging} unit={deputy}>

--- a/packages/client/src/components/dispatch/active-units/officers/OfficerColumn.tsx
+++ b/packages/client/src/components/dispatch/active-units/officers/OfficerColumn.tsx
@@ -104,7 +104,7 @@ export function OfficerColumn({ officer, nameAndCallsign, setTempUnit }: Props) 
       ]}
     >
       <span>
-        <Draggable canDrag={canDrag} type={DndActions.MoveUnitTo911Call} item={officer}>
+        <Draggable canDrag={canDrag} type={DndActions.MoveUnitTo911CallOrIncident} item={officer}>
           {({ isDragging }) => (
             <ActiveUnitsQualificationsCard canBeOpened={!isDragging} unit={officer}>
               <span

--- a/packages/client/src/components/leo/ActiveCalls.tsx
+++ b/packages/client/src/components/leo/ActiveCalls.tsx
@@ -45,7 +45,7 @@ export function ActiveCalls() {
   const [tempCall, setTempCall] = React.useState<Full911Call | null>(null);
 
   const { hasPermissions } = usePermission();
-  const { calls, setCalls, isDraggingUnit } = useDispatchState();
+  const { calls, setCalls, draggingUnit } = useDispatchState();
   const t = useTranslations("Calls");
   const leo = useTranslations("Leo");
   const common = useTranslations("Common");
@@ -364,7 +364,9 @@ export function ActiveCalls() {
           <div
             className={classNames(
               "grid place-items-center z-50 border-2 border-slate-500 bg-gray-4 fixed bottom-3 left-3 right-4 h-60 shadow-sm rounded-md transition-opacity",
-              isDraggingUnit ? "pointer-events-all opacity-100" : "pointer-events-none opacity-0",
+              draggingUnit === "call"
+                ? "pointer-events-all opacity-100"
+                : "pointer-events-none opacity-0",
             )}
           >
             <p>{t("dropToUnassign")}</p>

--- a/packages/client/src/components/leo/active-calls/AssignedUnitsColumn.tsx
+++ b/packages/client/src/components/leo/active-calls/AssignedUnitsColumn.tsx
@@ -43,7 +43,7 @@ export function AssignedUnitsColumn({ handleAssignToCall, isDispatch, call }: Pr
               <Draggable
                 canDrag={canDrag}
                 onDrag={(isDragging) => {
-                  dispatchState.setIsDraggingUnit(isDragging);
+                  dispatchState.setDraggingUnit(isDragging ? "call" : null);
                 }}
                 key={unit.id}
                 item={{ call, unit }}

--- a/packages/client/src/state/dispatchState.ts
+++ b/packages/client/src/state/dispatchState.ts
@@ -38,8 +38,8 @@ interface DispatchState {
   activeIncidents: LeoIncident[];
   setActiveIncidents(incidents: LeoIncident[]): void;
 
-  isDraggingUnit: boolean;
-  setIsDraggingUnit(v: boolean): void;
+  draggingUnit: "incident" | "call" | null;
+  setDraggingUnit(v: "incident" | "call" | null): void;
 }
 
 export const useDispatchState = create<DispatchState>((set) => ({
@@ -67,6 +67,6 @@ export const useDispatchState = create<DispatchState>((set) => ({
   activeIncidents: [],
   setActiveIncidents: (incidents) => set({ activeIncidents: incidents }),
 
-  isDraggingUnit: false,
-  setIsDraggingUnit: (v) => set({ isDraggingUnit: v }),
+  draggingUnit: null,
+  setDraggingUnit: (v) => set({ draggingUnit: v }),
 }));

--- a/packages/client/src/types/DndActions.ts
+++ b/packages/client/src/types/DndActions.ts
@@ -1,4 +1,5 @@
 export enum DndActions {
-  MoveUnitTo911Call = "MoveUnitTo911Call",
+  MoveUnitTo911CallOrIncident = "MoveUnitTo911Call",
   UnassignUnitFrom911Call = "UnassignUnitFrom911Call",
+  UnassignUnitFromIncident = "UnassignUnitFromIncident",
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

## Bug

- [ ] Related issues linked using `closes: #number`

## Feature

- [x] Related issues linked using #
- [x] There is only 1 db migration with no breaking changes.

## Translations

- [ ] `.json` files are formatted: `yarn format`
- [ ] Translations are correct
- [ ] New translation? It's been added to `next.config.js`
