### PR TITLE
🎉 feat: add simple warning if unit is inactive

### DIFF
--- a/packages/client/locales/en/leo.json
+++ b/packages/client/locales/en/leo.json
@@ -224,6 +224,7 @@
     "sendTone": "Send Tone",
     "toneSuccess": "Successfully sent out the tones to the selected forces",
     "toneNotification": "Tone Notification",
+    "unitWillBePlacedOffDuty": "Your unit will be placed off-duty soon because it has been inactive for some time. Please change the status of your unit to continue using it for this session.",
     "alert_deleteNote": "Are you sure you want to delete this note? This action cannot be undone.",
     "alert_deleteQualification": "Are you sure you want to delete this qualification? This action cannot be undone.",
     "alert_deleteDLExam": "Are you sure you want to delete this driver's license exam? This action cannot be undone.",

--- a/packages/client/src/components/shared/StatusesArea.tsx
+++ b/packages/client/src/components/shared/StatusesArea.tsx
@@ -105,9 +105,7 @@ export function StatusesArea<T extends ActiveOfficer | ActiveDeputy>({
     });
 
     if (json.id) {
-      console.log({ json });
-
-      setActiveUnit({ ...activeUnit, ...json, lastStatusChangeTimestamp: new Date() });
+      setActiveUnit({ ...activeUnit, ...json });
     }
   }
 

--- a/packages/client/src/components/shared/StatusesArea.tsx
+++ b/packages/client/src/components/shared/StatusesArea.tsx
@@ -105,7 +105,9 @@ export function StatusesArea<T extends ActiveOfficer | ActiveDeputy>({
     });
 
     if (json.id) {
-      setActiveUnit({ ...activeUnit, ...json });
+      console.log({ json });
+
+      setActiveUnit({ ...activeUnit, ...json, lastStatusChangeTimestamp: new Date() });
     }
   }
 

--- a/packages/client/src/hooks/shared/useUnitLastStatusChange.tsx
+++ b/packages/client/src/hooks/shared/useUnitLastStatusChange.tsx
@@ -1,0 +1,62 @@
+import type { EmsFdDeputy } from "@snailycad/types";
+import { isUnitCombined } from "@snailycad/utils";
+import { useAuth } from "context/AuthContext";
+import { useTranslations } from "next-intl";
+import * as React from "react";
+import type { ActiveOfficer } from "state/leoState";
+
+interface Options {
+  unit: EmsFdDeputy | ActiveOfficer | null;
+}
+
+export function useUnitLastStatusChange({ unit }: Options) {
+  const { cad } = useAuth();
+  const [isInactive, setIsInactive] = React.useState(false);
+
+  function isUnitInactive() {
+    if (!cad || !unit || isUnitCombined(unit)) return;
+
+    console.log({ unit });
+
+    const inactivityTimeout = cad.miscCadSettings?.inactivityTimeout ?? null;
+    if (!inactivityTimeout) {
+      return;
+    }
+
+    const FIVE_MINUTE_COOLDOWN = 60 * 5 * 1000;
+    const milliseconds = inactivityTimeout * (1000 * 60) - FIVE_MINUTE_COOLDOWN;
+    const lastStatusChangeTimestamp = unit.lastStatusChangeTimestamp;
+
+    const updatedAt = new Date(new Date().getTime() - milliseconds).getTime();
+    const lastStatusChanged = new Date(lastStatusChangeTimestamp).getTime();
+    const _isInactive = lastStatusChanged <= updatedAt;
+
+    if (_isInactive !== isInactive) {
+      setIsInactive(_isInactive);
+    }
+
+    return _isInactive;
+  }
+
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      isUnitInactive();
+    }, 1_000);
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, [cad, unit]); // eslint-disable-line
+
+  return { Component, isInactive };
+}
+
+function Component({ isInactive }: { isInactive: boolean }) {
+  const t = useTranslations("Leo");
+
+  return isInactive ? (
+    <div role="alert" className="p-2 px-3 my-2 font-semibold text-black bg-amber-500 rounded-md">
+      <p>{t("unitWillBePlacedOffDuty")}</p>
+    </div>
+  ) : null;
+}

--- a/packages/client/src/hooks/shared/useUnitLastStatusChange.tsx
+++ b/packages/client/src/hooks/shared/useUnitLastStatusChange.tsx
@@ -16,8 +16,6 @@ export function useUnitLastStatusChange({ unit }: Options) {
   function isUnitInactive() {
     if (!cad || !unit || isUnitCombined(unit)) return;
 
-    console.log({ unit });
-
     const inactivityTimeout = cad.miscCadSettings?.inactivityTimeout ?? null;
     if (!inactivityTimeout) {
       return;

--- a/packages/client/src/pages/ems-fd/index.tsx
+++ b/packages/client/src/pages/ems-fd/index.tsx
@@ -20,6 +20,7 @@ import type { EmsFdDeputy } from "@snailycad/types";
 import { Permissions } from "@snailycad/permissions";
 import { usePanicButton } from "hooks/shared/usePanicButton";
 import { useTones } from "hooks/global/useTones";
+import { useUnitLastStatusChange } from "hooks/shared/useUnitLastStatusChange";
 
 interface Props {
   activeDeputy: ActiveDeputy | null;
@@ -47,15 +48,16 @@ export default function EmsFDDashboard({ activeDeputy, calls, deputies }: Props)
   const signal100 = useSignal100();
   const tones = useTones("ems-fd");
   const panic = usePanicButton();
-  const state = useEmsFdState();
+  const emsFdState = useEmsFdState();
+  const unitLastStatusChange = useUnitLastStatusChange({ unit: emsFdState.activeDeputy });
   const { setCalls, activeDeputies, setActiveDeputies } = useDispatchState();
 
   React.useEffect(() => {
-    state.setActiveDeputy(activeDeputy);
-    state.setDeputies(deputies);
+    emsFdState.setActiveDeputy(activeDeputy);
+    emsFdState.setDeputies(deputies);
     setCalls(calls);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state.setActiveDeputy, state.setDeputies, setCalls, calls, deputies, activeDeputy]);
+  }, [emsFdState.setActiveDeputy, emsFdState.setDeputies, setCalls, calls, deputies, activeDeputy]);
 
   const t = useTranslations();
 
@@ -69,6 +71,7 @@ export default function EmsFDDashboard({ activeDeputy, calls, deputies }: Props)
       <signal100.Component enabled={signal100.enabled} audio={signal100.audio} />
       <panic.Component audio={panic.audio} unit={panic.unit} />
       <tones.Component audio={tones.audio} description={tones.description} />
+      <unitLastStatusChange.Component isInactive={unitLastStatusChange.isInactive} />
 
       <UtilityPanel>
         <div className="px-4">
@@ -78,8 +81,8 @@ export default function EmsFDDashboard({ activeDeputy, calls, deputies }: Props)
         <StatusesArea
           setUnits={setActiveDeputies}
           units={activeDeputies}
-          setActiveUnit={state.setActiveDeputy}
-          activeUnit={state.activeDeputy}
+          setActiveUnit={emsFdState.setActiveDeputy}
+          activeUnit={emsFdState.activeDeputy}
         />
       </UtilityPanel>
 
@@ -96,7 +99,7 @@ export default function EmsFDDashboard({ activeDeputy, calls, deputies }: Props)
 
       <SelectDeputyModal />
 
-      {state.activeDeputy ? (
+      {emsFdState.activeDeputy ? (
         <>
           <NotepadModal />
           <CreateMedicalRecordModal />

--- a/packages/client/src/pages/officer/index.tsx
+++ b/packages/client/src/pages/officer/index.tsx
@@ -35,6 +35,7 @@ import { useNameSearch } from "state/search/nameSearchState";
 import { useAuth } from "context/AuthContext";
 import { useFeatureEnabled } from "hooks/useFeatureEnabled";
 import { useTones } from "hooks/global/useTones";
+import { useUnitLastStatusChange } from "hooks/shared/useUnitLastStatusChange";
 
 const Modals = {
   CreateWarrantModal: dynamic(async () => {
@@ -93,6 +94,7 @@ export default function OfficerDashboard({
   const signal100 = useSignal100();
   const tones = useTones("leo");
   const panic = usePanicButton();
+  const unitLastStatusChange = useUnitLastStatusChange({ unit: leoState.activeOfficer });
   const { isOpen } = useModal();
   const { user } = useAuth();
   const { LEO_TICKETS } = useFeatureEnabled();
@@ -148,6 +150,7 @@ export default function OfficerDashboard({
       <signal100.Component enabled={signal100.enabled} audio={signal100.audio} />
       <panic.Component audio={panic.audio} unit={panic.unit} />
       <tones.Component audio={tones.audio} description={tones.description} />
+      <unitLastStatusChange.Component isInactive={unitLastStatusChange.isInactive} />
 
       <UtilityPanel>
         <div className="px-4">

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -688,6 +688,7 @@ export interface Officer {
   radioChannelId: string | null;
   user: Pick<User, "id" | "username" | "steamId">;
   callsigns?: IndividualDivisionCallsign[];
+  lastStatusChangeTimestamp: Date;
 }
 
 export interface IndividualDivisionCallsign {
@@ -1092,6 +1093,7 @@ export interface EmsFdDeputy {
   activeIncidentId: string | null;
   whitelistStatusId: string | null;
   whitelistStatus?: LeoWhitelistStatus | null;
+  lastStatusChangeTimestamp: Date;
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

## Bug

- [ ] Related issues linked using `closes: #number`

## Feature

- [x] Related issues linked using closes: #877 
- [x] There is only 1 db migration with no breaking changes.

## Translations

- [ ] `.json` files are formatted: `yarn format`
- [ ] Translations are correct
- [ ] New translation? It's been added to `next.config.js`
