### PR TITLE
copy-env fix

### DIFF
--- a/scripts/copy-env.mjs
+++ b/scripts/copy-env.mjs
@@ -8,6 +8,7 @@ async function addPortToClientPackageJson() {
   if (process.env.NODE_ENV === "development") return;
   const port = process.env.PORT_CLIENT;
   if (!port) return;
+  if (port === '3000') return;
 
   try {
     let dir = join(process.cwd(), "packages", "client");


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

## Bug

- [ ] Related issues linked using `closes: #number`

## Feature

- [ ] Related issues linked using `closes: #number`
- [ ] There is only 1 db migration with no breaking changes.

## Translations

- [ ] `.json` files are formatted: `yarn format`
- [ ] Translations are correct
- [ ] New translation? It's been added to `next.config.js`


the reason this is being opened because it would write to the package.json to start on port 3000 which is useless because thats the default, causing more issues when updating because of merge conflicts
