### PR TITLE
:tada: feat: ability to create records via 'snaily-cad-api-token'

### DIFF
--- a/packages/api/prisma/migrations/20220715065900_/migration.sql
+++ b/packages/api/prisma/migrations/20220715065900_/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Record" ALTER COLUMN "officerId" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Warrant" ALTER COLUMN "officerId" DROP NOT NULL;

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -1038,8 +1038,8 @@ model Record {
   type                 RecordType
   citizen              Citizen             @relation(fields: [citizenId], references: [id], onDelete: Cascade)
   citizenId            String
-  officer              Officer             @relation(fields: [officerId], references: [id], onDelete: Cascade)
-  officerId            String
+  officer              Officer?            @relation(fields: [officerId], references: [id], onDelete: Cascade)
+  officerId            String?
   violations           Violation[]
   createdAt            DateTime            @default(now())
   updatedAt            DateTime            @default(now()) @updatedAt
@@ -1066,8 +1066,8 @@ model Warrant {
   id                   String                   @id @default(uuid())
   citizen              Citizen                  @relation(fields: [citizenId], references: [id], onDelete: Cascade)
   citizenId            String
-  officer              Officer                  @relation(fields: [officerId], references: [id], onDelete: Cascade)
-  officerId            String
+  officer              Officer?                 @relation(fields: [officerId], references: [id], onDelete: Cascade)
+  officerId            String?
   assignedOfficers     AssignedWarrantOfficer[]
   description          String                   @db.Text
   status               WarrantStatus            @default(ACTIVE)

--- a/packages/api/src/controllers/record/RecordsController.ts
+++ b/packages/api/src/controllers/record/RecordsController.ts
@@ -77,7 +77,7 @@ export class RecordsController {
     @Context("activeOfficer") activeOfficer: (CombinedLeoUnit & { officers: Officer[] }) | Officer,
   ): Promise<APITypes.PostCreateWarrantData> {
     const data = validateSchema(CREATE_WARRANT_SCHEMA, body);
-    const officer = getFirstOfficerFromActiveOfficer({ activeOfficer });
+    const officer = getFirstOfficerFromActiveOfficer({ activeOfficer, allowDispatch: true });
 
     const citizen = await prisma.citizen.findUnique({
       where: {
@@ -92,7 +92,7 @@ export class RecordsController {
     const warrant = await prisma.warrant.create({
       data: {
         citizenId: citizen.id,
-        officerId: officer.id,
+        officerId: officer?.id ?? null,
         description: data.description,
         status: data.status as WarrantStatus,
       },
@@ -199,7 +199,7 @@ export class RecordsController {
     @Context("activeOfficer") activeOfficer: (CombinedLeoUnit & { officers: Officer[] }) | Officer,
   ): Promise<APITypes.PostRecordsData> {
     const data = validateSchema(CREATE_TICKET_SCHEMA, body);
-    const officer = getFirstOfficerFromActiveOfficer({ activeOfficer });
+    const officer = getFirstOfficerFromActiveOfficer({ activeOfficer, allowDispatch: true });
 
     const citizen = await prisma.citizen.findUnique({
       where: {
@@ -222,7 +222,7 @@ export class RecordsController {
       data: {
         type: data.type as RecordType,
         citizenId: citizen.id,
-        officerId: officer.id,
+        officerId: officer?.id ?? null,
         notes: data.notes,
         postal: String(data.postal),
         status: recordStatus,

--- a/packages/api/src/middlewares/ActiveOfficer.ts
+++ b/packages/api/src/middlewares/ActiveOfficer.ts
@@ -1,12 +1,17 @@
 import { Context, Middleware, Req, MiddlewareMethods } from "@tsed/common";
+import { Unauthorized } from "@tsed/exceptions";
 import { getSessionUser } from "lib/auth/getSessionUser";
 import { getActiveOfficer } from "lib/leo/activeOfficer";
 
 @Middleware()
 export class ActiveOfficer implements MiddlewareMethods {
   async use(@Req() req: Req, @Context() ctx: Context) {
-    const user = await getSessionUser(req);
-    const officer = await getActiveOfficer(req, user, ctx);
+    const user = await getSessionUser(req).catch(() => null);
+    if (!user && !req.originalUrl.includes("/v1/records")) {
+      throw new Unauthorized("Unauthorized");
+    }
+
+    const officer = user && (await getActiveOfficer(req, user, ctx));
 
     ctx.set("activeOfficer", officer);
   }

--- a/packages/client/src/components/leo/citizen-logs/ArrestReportsTab.tsx
+++ b/packages/client/src/components/leo/citizen-logs/ArrestReportsTab.tsx
@@ -79,13 +79,13 @@ export function ArrestReportsTab({ search, logs: data }: Props) {
             const type = TYPE_LABELS[record.type];
             const createdAt = record.createdAt;
             const officer = record.officer;
-            const officerName = makeUnitName(officer);
-            const callsign = generateCallsign(officer);
+            const officerName = officer && makeUnitName(officer);
+            const callsign = officer && generateCallsign(officer);
 
             return {
               type,
               citizen: `${item.citizen.name} ${item.citizen.surname}`,
-              officer: `${callsign} ${officerName}`,
+              officer: officer ? `${callsign} ${officerName}` : common("none"),
               postal: record.postal || common("none"),
               notes: (
                 <HoverCard

--- a/packages/client/src/components/leo/modals/NameSearchModal/tabs/RecordsTab.tsx
+++ b/packages/client/src/components/leo/modals/NameSearchModal/tabs/RecordsTab.tsx
@@ -159,7 +159,9 @@ function RecordsTable({ data }: { data: Record[] }) {
           .map((record) => ({
             violations: <ViolationsColumn violations={record.violations} />,
             postal: record.postal,
-            officer: `${generateCallsign(record.officer)} ${makeUnitName(record.officer)}`,
+            officer: record.officer
+              ? `${generateCallsign(record.officer)} ${makeUnitName(record.officer)}`
+              : common("none"),
             notes: record.notes || common("none"),
             createdAt: <FullDate>{record.createdAt}</FullDate>,
             actions: isCitizen ? null : (

--- a/packages/client/src/pages/officer/jail.tsx
+++ b/packages/client/src/pages/officer/jail.tsx
@@ -116,7 +116,9 @@ export default function Jail({ data }: Props) {
                     : null}
                 </Button>
               ),
-              officer: `${generateCallsign(record.officer)} ${makeUnitName(record.officer)}`,
+              officer: record.officer
+                ? `${generateCallsign(record.officer)} ${makeUnitName(record.officer)}`
+                : common("none"),
               jailTime,
               status,
               createdAt: <FullDate>{record.createdAt}</FullDate>,

--- a/packages/types/src/api/admin.ts
+++ b/packages/types/src/api/admin.ts
@@ -147,16 +147,7 @@ export type GetManageCitizenByIdData = GetManageCitizensData["citizens"][number]
  * @route /admin/manage/citizens/record-logs/:id
  */
 export type PostCitizenRecordLogsData = Prisma.Record & {
-  officer: Prisma.Officer & {
-    rank: Prisma.Value | null;
-    whitelistStatus:
-      | (Prisma.LeoWhitelistStatus & {
-          department: Prisma.DepartmentValue & { value: Prisma.Value };
-        })
-      | null;
-    /** todo: ... 10 ... */
-    activeDivisionCallsign: Prisma.IndividualDivisionCallsign | null;
-  };
+  officer?: Types.Officer | null;
   violations: (Prisma.Violation & {
     penalCode: Prisma.PenalCode & {
       warningApplicable: Prisma.WarningApplicable | null;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -319,7 +319,7 @@ export type Bolo = Prisma.Bolo & {
 };
 
 export type Record = Prisma.Record & {
-  officer: Officer;
+  officer?: Officer | null;
   violations: Violation[];
   seizedItems?: Prisma.SeizedItem[];
 };
@@ -329,7 +329,7 @@ export type RecordRelease = Prisma.RecordRelease & {
 };
 
 export type Warrant = Prisma.Warrant & {
-  officer?: Officer;
+  officer?: Officer | null;
 };
 
 export type RecordLog = Prisma.RecordLog & {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

## Bug

- [ ] Related issues linked using `closes: #number`

## Feature

- [x] Related issues linked using `closes: #number`
- [x] There is only 1 db migration with no breaking changes.

## Translations

- [ ] `.json` files are formatted: `yarn format`
- [ ] Translations are correct
- [ ] New translation? It's been added to `next.config.js`
