### PR TITLE
:tada: feat: add reauthorize session modal (ref #928)

### DIFF
--- a/packages/client/src/components/auth/login/LoginForm.tsx
+++ b/packages/client/src/components/auth/login/LoginForm.tsx
@@ -1,0 +1,203 @@
+import { Form, Formik, FormikHelpers } from "formik";
+import Link from "next/link";
+import { Discord, Steam } from "react-bootstrap-icons";
+import { FormField } from "components/form/FormField";
+import { Input, PasswordInput } from "components/form/inputs/Input";
+import { Loader } from "components/Loader";
+import { Button } from "components/Button";
+import { TwoFactorAuthScreen } from "components/auth/TwoFactorAuthScreen";
+import { findAPIUrl } from "lib/fetch";
+import { useRouter } from "next/router";
+import useFetch from "lib/useFetch";
+import { useTranslations } from "next-intl";
+import { useAuth } from "context/AuthContext";
+import { useFeatureEnabled } from "hooks/useFeatureEnabled";
+import { handleValidate } from "lib/handleValidate";
+import { AUTH_SCHEMA } from "@snailycad/schemas";
+import type { PostLoginUserData } from "@snailycad/types/api";
+import { canUseThirdPartyConnections } from "lib/utils";
+import { classNames } from "lib/classNames";
+
+const INITIAL_VALUES = {
+  username: "",
+  password: "",
+  totpCode: undefined as string | undefined,
+};
+
+interface Props {
+  isWithinModal?: boolean;
+  onFormSubmitted(data: { from: string; json: PostLoginUserData }): void;
+}
+
+export function LoginForm({ onFormSubmitted, isWithinModal }: Props) {
+  const router = useRouter();
+  const { state, execute } = useFetch();
+  const t = useTranslations("Auth");
+  const tError = useTranslations("Errors");
+  const { DISCORD_AUTH, ALLOW_REGULAR_LOGIN, STEAM_OAUTH } = useFeatureEnabled();
+  const { user } = useAuth();
+
+  const authMessages = {
+    banned: tError("userBanned"),
+    deleted: tError("userDeleted"),
+    discordNameInUse: tError("discordNameInUse"),
+    cannotRegisterFirstWithDiscord: tError("cannotRegisterFirstWithDiscord"),
+    steamNameInUse: tError("steamNameInUse"),
+    cannotRegisterFirstWithSteam: tError("cannotRegisterFirstWithSteam"),
+    userBanned: tError("userBanned"),
+    whitelistPending: tError("whitelistPending"),
+    whitelistDeclined: tError("whitelistDeclined"),
+  } as const;
+
+  const errorMessage = authMessages[router.query.error as keyof typeof authMessages];
+  const validate = handleValidate(AUTH_SCHEMA);
+
+  async function onSubmit(
+    values: typeof INITIAL_VALUES,
+    helpers: FormikHelpers<typeof INITIAL_VALUES>,
+  ) {
+    const { json, error } = await execute<PostLoginUserData, typeof INITIAL_VALUES>({
+      path: "/auth/login",
+      data: values,
+      method: "POST",
+      helpers,
+      noToast: "totpCodeRequired",
+    });
+
+    if (error === "totpCodeRequired") {
+      helpers.setFieldValue("totpCode", "");
+      return;
+    }
+
+    if (json.hasTempPassword) {
+      router.push({
+        pathname: "/auth/temp-password",
+        query: { tp: values.password },
+      });
+    } else if (json?.userId) {
+      const from = typeof router.query.from === "string" ? router.query.from : "/citizen";
+      onFormSubmitted({ from, json });
+    }
+  }
+
+  function handleDiscordLogin() {
+    const url = findAPIUrl();
+
+    const fullUrl = `${url}/auth/discord`;
+    window.location.href = fullUrl;
+  }
+
+  function handleSteamLogin() {
+    const url = findAPIUrl();
+
+    const fullUrl = `${url}/auth/steam`;
+    window.location.href = fullUrl;
+  }
+
+  function handleContinueAs() {
+    const from = typeof router.query.from === "string" ? router.query.from : "/citizen";
+    router.push(from);
+  }
+
+  const useThirdPartyConnectionsAbility = canUseThirdPartyConnections();
+  const showSteamOAuth = STEAM_OAUTH && useThirdPartyConnectionsAbility;
+  const showDiscordOAuth = DISCORD_AUTH && useThirdPartyConnectionsAbility;
+
+  const showHorizontalLine = ALLOW_REGULAR_LOGIN && (showSteamOAuth || showDiscordOAuth || !!user);
+
+  return (
+    <Formik validate={validate} onSubmit={onSubmit} initialValues={INITIAL_VALUES}>
+      {({ handleChange, errors, values, isValid }) => (
+        <Form
+          className={classNames(
+            isWithinModal ? "bg-transparent pb-3" : " shadow-md p-6 bg-gray-100 dark:bg-gray-2",
+            "relative w-full max-w-md rounded-lg z-10",
+          )}
+        >
+          {typeof values.totpCode !== "undefined" ? (
+            <TwoFactorAuthScreen errorMessage={errors.totpCode} isLoading={state === "loading"} />
+          ) : (
+            <>
+              <header className="mb-3">
+                <h1 className="text-3xl font-bold text-gray-800 dark:text-white">{t("login")}</h1>
+
+                {ALLOW_REGULAR_LOGIN ? (
+                  <Link href="/auth/register">
+                    <a
+                      href="/auth/register"
+                      className="inline-block mt-2 underline text-neutral-700 dark:text-gray-200"
+                    >
+                      {t("noAccount")}
+                    </a>
+                  </Link>
+                ) : null}
+              </header>
+
+              {errorMessage ? (
+                <p className="bg-red-500/80 text-black w-full py-1.5 px-3 my-3 rounded-md">
+                  {errorMessage}
+                </p>
+              ) : null}
+
+              {ALLOW_REGULAR_LOGIN ? (
+                <>
+                  <FormField errorMessage={errors.username} label={t("username")}>
+                    <Input type="text" name="username" onChange={handleChange} />
+                  </FormField>
+
+                  <FormField errorMessage={errors.password} label={t("password")}>
+                    <PasswordInput name="password" onChange={handleChange} />
+                  </FormField>
+
+                  <Button
+                    disabled={!isValid || state === "loading"}
+                    type="submit"
+                    className="flex items-center justify-center w-full gap-3 mt-5"
+                  >
+                    {state === "loading" ? <Loader /> : null} {t("login")}
+                  </Button>
+                </>
+              ) : null}
+
+              {showHorizontalLine ? (
+                <div className="my-7 flex items-center gap-2">
+                  <span className="h-[2px] bg-gray-3 w-full rounded-md" />
+                  <span className="min-w-fit text-sm uppercase dark:text-gray-300">{t("or")}</span>
+                  <span className="h-[2px] bg-gray-3 w-full rounded-md" />
+                </div>
+              ) : null}
+
+              {user && !isWithinModal ? (
+                <Button type="button" onClick={handleContinueAs} className="w-full mb-2">
+                  {t.rich("continueAs", { username: user.username })}
+                </Button>
+              ) : null}
+
+              {showDiscordOAuth ? (
+                <Button
+                  type="button"
+                  onClick={handleDiscordLogin}
+                  className="flex items-center justify-center gap-3 w-full"
+                >
+                  <Discord />
+                  {t("loginViaDiscord")}
+                </Button>
+              ) : null}
+
+              {showSteamOAuth ? (
+                <Button
+                  type="button"
+                  onClick={handleSteamLogin}
+                  className="flex items-center justify-center gap-3 w-full mt-2"
+                >
+                  <Steam />
+                  {t("loginViaSteam")}
+                </Button>
+              ) : null}
+            </>
+          )}
+        </Form>
+      )}
+    </Formik>
+  );
+}

--- a/packages/client/src/components/auth/login/ReauthorizeSessionModal.tsx
+++ b/packages/client/src/components/auth/login/ReauthorizeSessionModal.tsx
@@ -1,0 +1,30 @@
+import { Modal } from "components/modal/Modal";
+import { toastMessage } from "lib/toastMessage";
+import { useModal } from "state/modalState";
+import { ModalIds } from "types/ModalIds";
+import { LoginForm } from "./LoginForm";
+
+export function ReauthorizeSessionModal() {
+  const { isOpen, closeModal } = useModal();
+
+  function handleSubmit() {
+    toastMessage({
+      icon: "success",
+      title: "Reauthorized",
+      message: "You have been reauthorized. You can now continue to use SnailyCAD.",
+    });
+
+    closeModal(ModalIds.ReauthorizeSession);
+  }
+
+  return (
+    <Modal
+      className="w-[448px]"
+      title="Reauthorize Session"
+      onClose={() => closeModal(ModalIds.ReauthorizeSession)}
+      isOpen={isOpen(ModalIds.ReauthorizeSession)}
+    >
+      <LoginForm isWithinModal onFormSubmitted={handleSubmit} />
+    </Modal>
+  );
+}

--- a/packages/client/src/lib/getTranslation.ts
+++ b/packages/client/src/lib/getTranslation.ts
@@ -9,7 +9,7 @@ export async function getNextI18Config() {
 }
 
 export async function getTranslations(types: string[], locale = "en") {
-  const typesWithCommon = [...new Set(["common", ...types])];
+  const typesWithCommon = [...new Set(["common", "auth", ...types])];
   const paths = typesWithCommon.map((type) => path.join(cwd, `locales/${locale}/${type}.json`));
   const i18n = await getNextI18Config();
 

--- a/packages/client/src/lib/useFetch.ts
+++ b/packages/client/src/lib/useFetch.ts
@@ -5,6 +5,8 @@ import { useTranslations } from "use-intl";
 import Common from "../../locales/en/common.json";
 import type { FormikHelpers } from "formik";
 import { toastMessage } from "./toastMessage";
+import { useModal } from "state/modalState";
+import { ModalIds } from "types/ModalIds";
 
 interface UseFetchOptions {
   overwriteState: State | null;
@@ -32,6 +34,7 @@ interface Return<Data> {
 
 export default function useFetch({ overwriteState }: UseFetchOptions = { overwriteState: null }) {
   const [state, setState] = React.useState<State | null>(null);
+  const { openModal } = useModal();
 
   const t = useTranslations("Errors");
   const abortControllerRef = React.useRef<NullableAbortController>(null);
@@ -65,6 +68,10 @@ export default function useFetch({ overwriteState }: UseFetchOptions = { overwri
       const errorObj = getErrorObj(response);
 
       console.error(JSON.stringify({ DEBUG: errorObj }, null, 2));
+
+      if (response?.response?.status === 401) {
+        openModal(ModalIds.ReauthorizeSession);
+      }
 
       let hasAddedError = false as boolean; // as boolean because eslint gets upset otherwise.
       for (const error of errors) {

--- a/packages/client/src/pages/_app.tsx
+++ b/packages/client/src/pages/_app.tsx
@@ -16,6 +16,16 @@ import * as Sentry from "@sentry/react";
 import { BrowserTracing } from "@sentry/tracing";
 import { GoogleReCaptchaProvider } from "react-google-recaptcha-v3";
 import type { cad } from "@snailycad/types";
+import { useMounted } from "@casper124578/useful";
+import dynamic from "next/dynamic";
+
+const ReauthorizeSessionModal = dynamic(
+  async () =>
+    (await import("components/auth/login/ReauthorizeSessionModal")).ReauthorizeSessionModal,
+  {
+    ssr: false,
+  },
+);
 
 Sentry.init({
   dsn: "https://6e31d0dc886d482091e293edb73eb10e@o518232.ingest.sentry.io/6553264",
@@ -24,6 +34,7 @@ Sentry.init({
 });
 
 export default function App({ Component, router, pageProps }: AppProps) {
+  const isMounted = useMounted();
   const { hostname, protocol, port } = new URL(findAPIUrl());
   const url = `${protocol}//${hostname}:${port}`;
 
@@ -52,6 +63,7 @@ export default function App({ Component, router, pageProps }: AppProps) {
                     scriptProps={{ async: true, defer: true, appendTo: "body" }}
                     useRecaptchaNet
                   >
+                    {isMounted ? <ReauthorizeSessionModal /> : null}
                     <Component {...pageProps} />
                   </GoogleReCaptchaProvider>
                 </DndProvider>

--- a/packages/client/src/pages/auth/login.tsx
+++ b/packages/client/src/pages/auth/login.tsx
@@ -1,117 +1,32 @@
-import { Form, Formik, FormikHelpers } from "formik";
-import Link from "next/link";
-import { useRouter } from "next/router";
-import { AUTH_SCHEMA } from "@snailycad/schemas";
-import { Discord, Steam } from "react-bootstrap-icons";
-import useFetch from "lib/useFetch";
-import { FormField } from "components/form/FormField";
-import { Input, PasswordInput } from "components/form/inputs/Input";
-import { Loader } from "components/Loader";
-import { handleValidate } from "lib/handleValidate";
-import { useTranslations } from "use-intl";
 import type { GetServerSideProps } from "next";
 import { getTranslations } from "lib/getTranslation";
-import { Button } from "components/Button";
-import { findAPIUrl, handleRequest } from "lib/fetch";
-import { useFeatureEnabled } from "hooks/useFeatureEnabled";
+import { handleRequest } from "lib/fetch";
 import { Title } from "components/shared/Title";
 import { AuthScreenImages } from "components/auth/AuthScreenImages";
-import { TwoFactorAuthScreen } from "components/auth/TwoFactorAuthScreen";
-import { canUseThirdPartyConnections } from "lib/utils";
-import { useAuth } from "context/AuthContext";
 import { LocalhostDetector } from "components/auth/LocalhostDetector";
 import { parseCookies } from "nookies";
 import { VersionDisplay } from "components/shared/VersionDisplay";
+import { useAuth } from "context/AuthContext";
+import { useTranslations } from "next-intl";
+import { LoginForm } from "components/auth/login/LoginForm";
+import { useRouter } from "next/router";
 import type { PostLoginUserData } from "@snailycad/types/api";
 
-const INITIAL_VALUES = {
-  username: "",
-  password: "",
-  totpCode: undefined as string | undefined,
-};
-
 export default function Login() {
-  const router = useRouter();
-  const { state, execute } = useFetch();
+  const { cad } = useAuth();
   const t = useTranslations("Auth");
-  const tError = useTranslations("Errors");
-  const { DISCORD_AUTH, ALLOW_REGULAR_LOGIN, STEAM_OAUTH } = useFeatureEnabled();
-  const { user, cad } = useAuth();
+  const router = useRouter();
 
-  const authMessages = {
-    banned: tError("userBanned"),
-    deleted: tError("userDeleted"),
-    discordNameInUse: tError("discordNameInUse"),
-    cannotRegisterFirstWithDiscord: tError("cannotRegisterFirstWithDiscord"),
-    steamNameInUse: tError("steamNameInUse"),
-    cannotRegisterFirstWithSteam: tError("cannotRegisterFirstWithSteam"),
-    userBanned: tError("userBanned"),
-    whitelistPending: tError("whitelistPending"),
-    whitelistDeclined: tError("whitelistDeclined"),
-  } as const;
-
-  const errorMessage = authMessages[router.query.error as keyof typeof authMessages];
-  const validate = handleValidate(AUTH_SCHEMA);
-
-  async function onSubmit(
-    values: typeof INITIAL_VALUES,
-    helpers: FormikHelpers<typeof INITIAL_VALUES>,
-  ) {
-    const { json, error } = await execute<PostLoginUserData, typeof INITIAL_VALUES>({
-      path: "/auth/login",
-      data: values,
-      method: "POST",
-      helpers,
-      noToast: "totpCodeRequired",
-    });
-
-    if (error === "totpCodeRequired") {
-      helpers.setFieldValue("totpCode", "");
-      return;
-    }
-
-    if (json.hasTempPassword) {
-      router.push({
-        pathname: "/auth/temp-password",
-        query: { tp: values.password },
+  async function handleSubmit({ from, json }: { from: string; json: PostLoginUserData }) {
+    if (process.env.IFRAME_SUPPORT_ENABLED === "true" && json.session) {
+      await fetch("/api/token", {
+        method: "POST",
+        body: json.session,
       });
-    } else if (json?.userId) {
-      if (process.env.IFRAME_SUPPORT_ENABLED === "true" && json.session) {
-        await fetch("/api/token", {
-          method: "POST",
-          body: json.session,
-        });
-      }
-
-      const from = typeof router.query.from === "string" ? router.query.from : "/citizen";
-      router.push(from);
     }
-  }
 
-  function handleDiscordLogin() {
-    const url = findAPIUrl();
-
-    const fullUrl = `${url}/auth/discord`;
-    window.location.href = fullUrl;
-  }
-
-  function handleSteamLogin() {
-    const url = findAPIUrl();
-
-    const fullUrl = `${url}/auth/steam`;
-    window.location.href = fullUrl;
-  }
-
-  function handleContinueAs() {
-    const from = typeof router.query.from === "string" ? router.query.from : "/citizen";
     router.push(from);
   }
-
-  const useThirdPartyConnectionsAbility = canUseThirdPartyConnections();
-  const showSteamOAuth = STEAM_OAUTH && useThirdPartyConnectionsAbility;
-  const showDiscordOAuth = DISCORD_AUTH && useThirdPartyConnectionsAbility;
-
-  const showHorizontalLine = ALLOW_REGULAR_LOGIN && (showSteamOAuth || showDiscordOAuth || !!user);
 
   return (
     <>
@@ -121,101 +36,8 @@ export default function Login() {
         <AuthScreenImages />
         <LocalhostDetector />
 
-        <Formik validate={validate} onSubmit={onSubmit} initialValues={INITIAL_VALUES}>
-          {({ handleChange, errors, values, isValid }) => (
-            <Form className="relative w-full max-w-md p-6 bg-gray-100 rounded-lg shadow-md dark:bg-gray-2 z-10">
-              {typeof values.totpCode !== "undefined" ? (
-                <TwoFactorAuthScreen
-                  errorMessage={errors.totpCode}
-                  isLoading={state === "loading"}
-                />
-              ) : (
-                <>
-                  <header className="mb-3">
-                    <h1 className="text-3xl font-bold text-gray-800 dark:text-white">
-                      {t("login")}
-                    </h1>
+        <LoginForm onFormSubmitted={handleSubmit} />
 
-                    {ALLOW_REGULAR_LOGIN ? (
-                      <Link href="/auth/register">
-                        <a
-                          href="/auth/register"
-                          className="inline-block mt-2 underline text-neutral-700 dark:text-gray-200"
-                        >
-                          {t("noAccount")}
-                        </a>
-                      </Link>
-                    ) : null}
-                  </header>
-
-                  {errorMessage ? (
-                    <p className="bg-red-500/80 text-black w-full py-1.5 px-3 my-3 rounded-md">
-                      {errorMessage}
-                    </p>
-                  ) : null}
-
-                  {ALLOW_REGULAR_LOGIN ? (
-                    <>
-                      <FormField errorMessage={errors.username} label={t("username")}>
-                        <Input type="text" name="username" onChange={handleChange} />
-                      </FormField>
-
-                      <FormField errorMessage={errors.password} label={t("password")}>
-                        <PasswordInput name="password" onChange={handleChange} />
-                      </FormField>
-
-                      <Button
-                        disabled={!isValid || state === "loading"}
-                        type="submit"
-                        className="flex items-center justify-center w-full gap-3 mt-5"
-                      >
-                        {state === "loading" ? <Loader /> : null} {t("login")}
-                      </Button>
-                    </>
-                  ) : null}
-
-                  {showHorizontalLine ? (
-                    <div className="my-7 flex items-center gap-2">
-                      <span className="h-[2px] bg-gray-3 w-full rounded-md" />
-                      <span className="min-w-fit text-sm uppercase dark:text-gray-300">
-                        {t("or")}
-                      </span>
-                      <span className="h-[2px] bg-gray-3 w-full rounded-md" />
-                    </div>
-                  ) : null}
-
-                  {user ? (
-                    <Button type="button" onClick={handleContinueAs} className="w-full mb-2">
-                      {t.rich("continueAs", { username: user.username })}
-                    </Button>
-                  ) : null}
-
-                  {showDiscordOAuth ? (
-                    <Button
-                      type="button"
-                      onClick={handleDiscordLogin}
-                      className="flex items-center justify-center gap-3 w-full"
-                    >
-                      <Discord />
-                      {t("loginViaDiscord")}
-                    </Button>
-                  ) : null}
-
-                  {showSteamOAuth ? (
-                    <Button
-                      type="button"
-                      onClick={handleSteamLogin}
-                      className="flex items-center justify-center gap-3 w-full mt-2"
-                    >
-                      <Steam />
-                      {t("loginViaSteam")}
-                    </Button>
-                  ) : null}
-                </>
-              )}
-            </Form>
-          )}
-        </Formik>
         <VersionDisplay cad={cad} />
       </main>
     </>

--- a/packages/client/src/types/ModalIds.ts
+++ b/packages/client/src/types/ModalIds.ts
@@ -1,4 +1,6 @@
 export const enum ModalIds {
+  ReauthorizeSession = "ReauthorizeSessionModal",
+
   RegisterVehicle = "RegisterVehicleModal",
   RegisterWeapon = "RegisterWeaponModal",
   ManageLicenses = "ManageLicensesModal",


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

## Bug

- [ ] Related issues linked using `closes: #number`

## Feature

- [x] Related issues linked using ref #928 
- [x] There is only 1 db migration with no breaking changes.

## Translations

- [ ] `.json` files are formatted: `yarn format`
- [ ] Translations are correct
- [ ] New translation? It's been added to `next.config.js`

https://user-images.githubusercontent.com/53900565/179175713-6bf10cfd-3a70-4dd5-babe-5452a37ab341.mov


