### PR TITLE
:tada: feat: able to grant users manage cad-settings permissions

### DIFF
--- a/packages/api/src/controllers/admin/manage/cad-settings/CADImagesController.ts
+++ b/packages/api/src/controllers/admin/manage/cad-settings/CADImagesController.ts
@@ -8,13 +8,19 @@ import { BadRequest } from "@tsed/exceptions";
 import { MultipartFile, PlatformMulterFile, UseBefore } from "@tsed/common";
 import { AllowedFileExtension, allowedFileExtensions } from "@snailycad/config";
 import fs from "node:fs";
-import type { cad } from "@prisma/client";
+import { cad, Rank } from "@prisma/client";
 import { randomUUID } from "node:crypto";
+import { Permissions } from "@snailycad/permissions";
+import { UsePermissions } from "middlewares/UsePermissions";
 
 @Controller("/admin/manage/cad-settings/image")
 export class ManageCitizensController {
   @UseBefore(IsAuth)
   @Post("/")
+  @UsePermissions({
+    fallback: (u) => u.rank === Rank.OWNER,
+    permissions: [Permissions.ManageCADSettings],
+  })
   async uploadLogoToCAD(
     @Context("cad") cad: cad,
     @MultipartFile("image") file: PlatformMulterFile,
@@ -41,6 +47,10 @@ export class ManageCitizensController {
 
   @UseBefore(IsAuth)
   @Post("/auth")
+  @UsePermissions({
+    fallback: (u) => u.rank === Rank.OWNER,
+    permissions: [Permissions.ManageCADSettings],
+  })
   async uploadAuthImagesToCAD(
     @Context("cad") cad: cad,
     @MultipartFile("authScreenHeaderImageId") header?: PlatformMulterFile,

--- a/packages/api/src/controllers/admin/manage/cad-settings/CadSettings.ts
+++ b/packages/api/src/controllers/admin/manage/cad-settings/CadSettings.ts
@@ -14,10 +14,11 @@ import { Req, UseBefore } from "@tsed/common";
 import { Socket } from "services/SocketService";
 import { nanoid } from "nanoid";
 import { validateSchema } from "lib/validateSchema";
-import type { cad, Feature, JailTimeScale } from "@prisma/client";
+import { cad, Feature, JailTimeScale, Rank } from "@prisma/client";
 import { getCADVersion } from "@snailycad/utils/version";
 import { getSessionUser } from "lib/auth/getSessionUser";
 import type * as APITypes from "@snailycad/types/api";
+import { Permissions, UsePermissions } from "middlewares/UsePermissions";
 
 @Controller("/admin/manage/cad-settings")
 export class ManageCitizensController {
@@ -44,6 +45,10 @@ export class ManageCitizensController {
 
   @Put("/")
   @UseBefore(IsAuth)
+  @UsePermissions({
+    fallback: (u) => u.rank === Rank.OWNER,
+    permissions: [Permissions.ManageCADSettings],
+  })
   async updateCadSettings(
     @Context("cad") cad: cad,
     @BodyParams() body: unknown,
@@ -75,6 +80,10 @@ export class ManageCitizensController {
 
   @Put("/features")
   @UseBefore(IsAuth)
+  @UsePermissions({
+    fallback: (u) => u.rank === Rank.OWNER,
+    permissions: [Permissions.ManageCADSettings],
+  })
   async updateCadFeatures(
     @Context("cad") cad: cad,
     @BodyParams() body: unknown,
@@ -105,6 +114,10 @@ export class ManageCitizensController {
 
   @Put("/misc")
   @UseBefore(IsAuth)
+  @UsePermissions({
+    fallback: (u) => u.rank === Rank.OWNER,
+    permissions: [Permissions.ManageCADSettings],
+  })
   async updateMiscSettings(
     @Context("cad") cad: cad,
     @BodyParams() body: unknown,
@@ -142,6 +155,10 @@ export class ManageCitizensController {
 
   @Put("/auto-set-properties")
   @UseBefore(IsAuth)
+  @UsePermissions({
+    fallback: (u) => u.rank === Rank.OWNER,
+    permissions: [Permissions.ManageCADSettings],
+  })
   async updateAutoSetProperties(
     @Context("cad") cad: cad,
     @BodyParams() body: unknown,
@@ -170,6 +187,10 @@ export class ManageCitizensController {
 
   @Put("/api-token")
   @UseBefore(IsAuth)
+  @UsePermissions({
+    fallback: (u) => u.rank === Rank.OWNER,
+    permissions: [Permissions.ManageCADSettings],
+  })
   async updateApiToken(
     @Context("cad") cad: cad,
     @BodyParams() body: any,
@@ -216,6 +237,10 @@ export class ManageCitizensController {
 
   @Delete("/api-token")
   @UseBefore(IsAuth)
+  @UsePermissions({
+    fallback: (u) => u.rank === Rank.OWNER,
+    permissions: [Permissions.ManageCADSettings],
+  })
   async regenerateApiToken(@Context("cad") cad: cad) {
     if (!cad.apiTokenId) {
       throw new BadRequest("noApiTokenId");

--- a/packages/api/src/controllers/admin/manage/cad-settings/discord/DiscordSettingsController.ts
+++ b/packages/api/src/controllers/admin/manage/cad-settings/discord/DiscordSettingsController.ts
@@ -4,13 +4,15 @@ import { Get, Post } from "@tsed/schema";
 import { RESTGetAPIGuildRolesResult, Routes } from "discord-api-types/v10";
 import { IsAuth } from "middlewares/IsAuth";
 import { prisma } from "lib/prisma";
-import type { cad, DiscordRole } from "@prisma/client";
+import { Rank, cad, DiscordRole } from "@prisma/client";
 import { BadRequest } from "@tsed/exceptions";
 import { DISCORD_SETTINGS_SCHEMA } from "@snailycad/schemas";
 import { validateSchema } from "lib/validateSchema";
 import { getRest } from "lib/discord/config";
 import { manyToManyHelper } from "utils/manyToMany";
 import type * as APITypes from "@snailycad/types/api";
+import { Permissions } from "@snailycad/permissions";
+import { UsePermissions } from "middlewares/UsePermissions";
 
 const guildId = process.env.DISCORD_SERVER_ID;
 
@@ -65,6 +67,10 @@ export class DiscordSettingsController {
   }
 
   @Post("/")
+  @UsePermissions({
+    fallback: (u) => u.rank === Rank.OWNER,
+    permissions: [Permissions.ManageCADSettings],
+  })
   async setRoleTypes(
     @Context("cad") cad: cad,
     @BodyParams() body: unknown,

--- a/packages/api/src/controllers/admin/manage/cad-settings/discord/DiscordWebhooksController.ts
+++ b/packages/api/src/controllers/admin/manage/cad-settings/discord/DiscordWebhooksController.ts
@@ -10,7 +10,7 @@ import {
 } from "discord-api-types/v10";
 import { IsAuth } from "middlewares/IsAuth";
 import { prisma } from "lib/prisma";
-import type { cad, DiscordWebhook, DiscordWebhookType, MiscCadSettings } from "@prisma/client";
+import { cad, DiscordWebhook, DiscordWebhookType, MiscCadSettings, Rank } from "@prisma/client";
 import { BadRequest } from "@tsed/exceptions";
 import { DISCORD_WEBHOOKS_SCHEMA } from "@snailycad/schemas";
 import { validateSchema } from "lib/validateSchema";
@@ -18,6 +18,7 @@ import { getRest } from "lib/discord/config";
 import type * as APITypes from "@snailycad/types/api";
 import { resolve } from "node:path";
 import { encodeFromFile } from "@snaily-cad/image-data-uri";
+import { Permissions, UsePermissions } from "middlewares/UsePermissions";
 
 const guildId = process.env.DISCORD_SERVER_ID;
 
@@ -25,6 +26,10 @@ const guildId = process.env.DISCORD_SERVER_ID;
 @Controller("/admin/manage/cad-settings/discord/webhooks")
 export class DiscordWebhooksController {
   @Get("/")
+  @UsePermissions({
+    fallback: (u) => u.rank === Rank.OWNER,
+    permissions: [Permissions.ManageCADSettings],
+  })
   async getGuildChannels(@Context("cad") cad: cad): Promise<APITypes.GetCADDiscordWebhooksData> {
     if (!guildId) {
       throw new BadRequest("mustSetBotTokenGuildId");
@@ -62,6 +67,10 @@ export class DiscordWebhooksController {
   }
 
   @Post("/")
+  @UsePermissions({
+    fallback: (u) => u.rank === Rank.OWNER,
+    permissions: [Permissions.ManageCADSettings],
+  })
   async setRoleTypes(
     @Context("cad")
     cad: cad & { miscCadSettings: MiscCadSettings & { webhooks: DiscordWebhook[] } },

--- a/packages/api/src/controllers/dispatch/911-calls/Calls911Controller.ts
+++ b/packages/api/src/controllers/dispatch/911-calls/Calls911Controller.ts
@@ -316,6 +316,7 @@ export class Calls911Controller {
 
     const unitPromises = call.assignedUnits.map(async (unit) => {
       const { prismaName, unitId } = getPrismaNameActiveCallIncident({ unit });
+      if (!prismaName) return;
 
       // @ts-expect-error method has the same properties
       return prisma[prismaName].update({

--- a/packages/api/src/controllers/leo/incidents/IncidentController.ts
+++ b/packages/api/src/controllers/leo/incidents/IncidentController.ts
@@ -254,6 +254,7 @@ export class IncidentController {
     await Promise.all(
       incident.unitsInvolved.map(async (unit) => {
         const { prismaName, unitId } = getPrismaNameActiveCallIncident({ unit });
+        if (!prismaName) return;
 
         // @ts-expect-error method has the same properties
         await prisma[prismaName].update({

--- a/packages/api/src/middlewares/auth/getUser.ts
+++ b/packages/api/src/middlewares/auth/getUser.ts
@@ -1,10 +1,10 @@
 import { WhitelistStatus } from "@prisma/client";
 import { allPermissions } from "@snailycad/permissions";
 import type { Req } from "@tsed/common";
-import { BadRequest, Forbidden, Unauthorized } from "@tsed/exceptions";
+import { BadRequest, Unauthorized } from "@tsed/exceptions";
 import { getSessionUser } from "lib/auth/getSessionUser";
 import { prisma } from "lib/prisma";
-import { hasPermissionForReq, isRouteDisabled } from "./utils";
+import { isRouteDisabled } from "./utils";
 
 interface GetUserFromCADAPITokenOptions {
   req: Req;
@@ -45,11 +45,6 @@ export async function getUserFromCADAPIToken(options: GetUserFromCADAPITokenOpti
 
 export async function getUserFromSession(options: Pick<GetUserFromCADAPITokenOptions, "req">) {
   const user = await getSessionUser(options.req, false);
-
-  const hasPermission = hasPermissionForReq({ ...options, user });
-  if (!hasPermission) {
-    throw new Forbidden("Invalid Permissions");
-  }
 
   const user2FA = await prisma.user2FA.findFirst({
     where: { userId: user.id },

--- a/packages/api/src/middlewares/auth/utils.ts
+++ b/packages/api/src/middlewares/auth/utils.ts
@@ -1,5 +1,5 @@
 import type { cad, User } from "@prisma/client";
-import { DISABLED_API_TOKEN_ROUTES, Method, PERMISSION_ROUTES } from "@snailycad/config";
+import { DISABLED_API_TOKEN_ROUTES, Method } from "@snailycad/config";
 import type { GetUserData } from "@snailycad/types/api";
 import type { Req } from "@tsed/common";
 import { userProperties } from "lib/auth/getSessionUser";
@@ -30,28 +30,6 @@ export function isRouteDisabled(options: Pick<Options, "req">) {
   }
 
   return false;
-}
-
-export function hasPermissionForReq(options: Options) {
-  const url = options.req.originalUrl.toLowerCase();
-  const requestMethod = options.req.method.toUpperCase() as Method;
-
-  const [route] = PERMISSION_ROUTES.filter(([m, route]) => {
-    const urlWithBackslash = url.at(-1) === "/" ? url : `${url}/`;
-    const isMethodTrue = m === "*" ? true : m.includes(requestMethod);
-
-    const isTrue = (route.route === urlWithBackslash || route.route === url) && isMethodTrue;
-    return isTrue;
-  });
-
-  if (route) {
-    const [, , callback] = route;
-    const hasPermission = callback(options.user);
-
-    return hasPermission;
-  }
-
-  return true;
 }
 
 const THREE_MIN_TIMEOUT_MS = 60 * 1000 * 3;

--- a/packages/client/src/components/admin/Sidebar.tsx
+++ b/packages/client/src/components/admin/Sidebar.tsx
@@ -1,15 +1,13 @@
 import * as React from "react";
-import { useAuth } from "context/AuthContext";
 import { useFeatureEnabled } from "hooks/useFeatureEnabled";
 import { classNames } from "lib/classNames";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { Rank } from "@snailycad/types";
 import { useTranslations } from "use-intl";
 import { useViewport } from "@casper124578/useful/hooks/useViewport";
 import { importRoutes, managementRoutes, SidebarRoute, valueRoutes } from "./Sidebar/routes";
 import { usePermission } from "hooks/usePermission";
-import { defaultPermissions } from "@snailycad/permissions";
+import { defaultPermissions, Permissions } from "@snailycad/permissions";
 import { SidebarSection } from "./Sidebar/SidebarSection";
 
 export function AdminSidebar() {
@@ -19,7 +17,6 @@ export function AdminSidebar() {
   const t = useTranslations();
   const man = useTranslations("Management");
   const router = useRouter();
-  const { user } = useAuth();
 
   function isMActive(path: string) {
     return router.pathname === path;
@@ -56,7 +53,10 @@ export function AdminSidebar() {
       >
         <div className={menuOpen ? "block" : "hidden nav:block w-full"} id="sidebar-content">
           <SidebarSection
-            permissions={defaultPermissions.defaultManagementPermissions}
+            permissions={[
+              ...defaultPermissions.defaultManagementPermissions,
+              ...defaultPermissions.defaultOwnerPermissions,
+            ]}
             title={man("management")}
           >
             <>
@@ -73,15 +73,13 @@ export function AdminSidebar() {
                 );
               })}
 
-              {user?.rank === Rank.OWNER ? (
-                <SidebarItem
-                  route={null}
-                  isActive={isMActive("/admin/manage/cad-settings")}
-                  href="/admin/manage/cad-settings"
-                  text={man("MANAGE_CAD_SETTINGS")}
-                  onRouteClick={() => setMenuOpen(false)}
-                />
-              ) : null}
+              <SidebarItem
+                route={{ permissions: [Permissions.ManageCADSettings], type: "CAD_SETTINGS" }}
+                isActive={isMActive("/admin/manage/cad-settings")}
+                href="/admin/manage/cad-settings"
+                text={man("MANAGE_CAD_SETTINGS")}
+                onRouteClick={() => setMenuOpen(false)}
+              />
             </>
           </SidebarSection>
 

--- a/packages/client/src/components/admin/manage/users/ManagePermissionsModal.tsx
+++ b/packages/client/src/components/admin/manage/users/ManagePermissionsModal.tsx
@@ -52,6 +52,10 @@ const groups = [
     name: "Other",
     permissions: defaultPermissions.otherDefaultPermissions,
   },
+  {
+    name: "Owner",
+    permissions: [Permissions.ManageCADSettings],
+  },
 ];
 
 export function ManagePermissionsModal({ user, onUpdate, isReadOnly }: Props) {

--- a/packages/client/src/components/admin/manage/users/ManagePermissionsModal.tsx
+++ b/packages/client/src/components/admin/manage/users/ManagePermissionsModal.tsx
@@ -215,6 +215,7 @@ function makePermissionsData(data: Record<PermissionNames, boolean>) {
 export function formatPermissionName(permission: string) {
   // todo: whoops
   if (permission === Permissions.ManageDMV) return "Manage DMV";
+  if (permission === Permissions.ManageCADSettings) return "Manage CAD-Settings";
 
   return permission.match(/[A-Z][a-z]+/g)?.join(" ") ?? permission;
 }

--- a/packages/client/src/context/AuthContext.tsx
+++ b/packages/client/src/context/AuthContext.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useRouter } from "next/router";
 import { getSessionUser } from "lib/auth";
-import { cad as CAD, Rank, User } from "@snailycad/types";
+import type { cad as CAD, User } from "@snailycad/types";
 import { Loader } from "components/Loader";
 import { useIsRouteFeatureEnabled } from "hooks/auth/useIsRouteFeatureEnabled";
 import { useListener } from "@casper124578/use-socket.io";
@@ -26,14 +26,9 @@ interface ProviderProps {
   };
 }
 
-const PERMISSIONS: Record<string, (user: User) => boolean> = {
-  "/admin/manage/cad-settings": (user) => user.rank === Rank.OWNER,
-};
-
 const NO_LOADING_ROUTES = ["/403", "/404", "/auth/login", "/auth/register"];
 
 export function AuthProvider({ initialData, children }: ProviderProps) {
-  const [isForbidden, setForbidden] = React.useState(false);
   const [user, setUser] = React.useState<User | null>(initialData.session ?? null);
   const [cad, setCad] = React.useState<CAD | null>(
     initialData.session?.cad ?? initialData.cad ?? null,
@@ -63,18 +58,6 @@ export function AuthProvider({ initialData, children }: ProviderProps) {
     const isDarkTheme = user?.isDarkTheme ?? savedDarkTheme;
     _setBodyTheme(isDarkTheme);
   }, [user?.isDarkTheme, initialData.userSavedIsDarkTheme]);
-
-  React.useEffect(() => {
-    if (user) {
-      const hasPermission = hasPermissionForCurrentRoute(router.pathname, user);
-
-      if (!hasPermission) {
-        setForbidden(true);
-        router.push("/403");
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user, router.pathname]);
 
   React.useEffect(() => {
     handleGetUser();
@@ -110,7 +93,7 @@ export function AuthProvider({ initialData, children }: ProviderProps) {
 
   const value = { user, cad, setCad, setUser };
 
-  if ((!NO_LOADING_ROUTES.includes(router.pathname) && !user) || isForbidden) {
+  if (!NO_LOADING_ROUTES.includes(router.pathname) && !user) {
     return (
       <div id="unauthorized" className="fixed inset-0 grid bg-transparent place-items-center">
         <span aria-label="loading...">
@@ -149,15 +132,4 @@ function _setBodyTheme(isDarkTheme: boolean) {
   }
 
   window.document.body.classList.add("dark");
-}
-
-function hasPermissionForCurrentRoute(path: string, user: User) {
-  const key = Object.keys(PERMISSIONS).find((v) => path.startsWith(v));
-  if (!key) return true;
-
-  const pathPermission = PERMISSIONS[key];
-
-  if (typeof pathPermission !== "function") return true;
-
-  return pathPermission(user);
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -22,7 +22,6 @@
     "test": "yarn vitest run"
   },
   "devDependencies": {
-    "@snailycad/types": "1.17.0",
     "tsup": "^6.1.3",
     "typescript": "^4.7.4",
     "vite": "^3.0.0",

--- a/packages/config/src/routes.ts
+++ b/packages/config/src/routes.ts
@@ -1,4 +1,3 @@
-import type { User as _User } from "@snailycad/types";
 export type Method = "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
 
 /**
@@ -9,18 +8,4 @@ export type DisabledRoute = [string, Method[] | "*"];
 export const DISABLED_API_TOKEN_ROUTES: DisabledRoute[] = [
   ["/v1/user", "*"],
   ["/v1/admin/manage/cad-settings", "*"],
-];
-
-type Rank = "ADMIN" | "OWNER" | "USER";
-type UserPicks = "isLeo" | "isDispatch" | "isEmsFd" | "isSupervisor" | "isTaxi" | "isTow";
-type User = Pick<_User, UserPicks> & { rank: Rank };
-
-interface Route {
-  route: string;
-}
-export type PermissionRoute = [Method[] | "*", Route, (user: User) => boolean];
-
-export const PERMISSION_ROUTES: PermissionRoute[] = [
-  [["GET"], { route: "/v1/admin/manage/cad-settings/discord/roles" }, () => true],
-  ["*", { route: "/v1/admin/manage/cad-settings" }, (u) => u.rank === "OWNER"],
 ];

--- a/packages/permissions/src/defaults/admin.ts
+++ b/packages/permissions/src/defaults/admin.ts
@@ -59,8 +59,11 @@ export const defaultCourthousePermissions = [
   Permissions.ManageNameChangeRequests,
 ];
 
+export const defaultOwnerPermissions = [Permissions.ManageCADSettings];
+
 export const allDefaultAdminPermissions = [
   ...defaultManagementPermissions,
   ...defaultImportPermissions,
   ...defaultValuePermissions,
+  ...defaultOwnerPermissions,
 ];

--- a/packages/permissions/src/permissions.ts
+++ b/packages/permissions/src/permissions.ts
@@ -36,6 +36,8 @@ export enum Permissions {
   CreateBusinesses = "CreateBusinesses",
 
   // admin related
+  ManageCADSettings = "ManageCADSettings",
+
   ViewUsers = "ViewUsers",
   ManageUsers = "ManageUsers",
   BanUsers = "BanUsers",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1694,7 +1694,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@snailycad/config@workspace:packages/config"
   dependencies:
-    "@snailycad/types": 1.17.0
     tsup: ^6.1.3
     typescript: ^4.7.4
     vite: ^3.0.0


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

## Bug

- [ ] Related issues linked using `closes: #number`

## Feature

- [x] Related issues linked using closes: #987 
- [x] There is only 1 db migration with no breaking changes.

## Translations

- [ ] `.json` files are formatted: `yarn format`
- [ ] Translations are correct
- [ ] New translation? It's been added to `next.config.js`
