### PR TITLE
:globe_with_meridians: Add 'Additional Info' in FRA and DEU

### DIFF
--- a/packages/client/locales/de_DE/citizen.json
+++ b/packages/client/locales/de_DE/citizen.json
@@ -37,6 +37,7 @@
     "create911Call": "911 Anruf erstellen",
     "socialSecurityNumber": "Sozialversicherungsnummer",
     "occupation": "Beruf",
+    "additionalInfo": "Zusatsinfo",
     "manageOccupation": "Berufe verwalten",
     "manageLicenses": "Lizenzen verwalten",
     "licenses": "Lizenzen",

--- a/packages/client/locales/fr_FRA/citizen.json
+++ b/packages/client/locales/fr_FRA/citizen.json
@@ -37,6 +37,7 @@
     "create911Call": "Appeler le 911",
     "socialSecurityNumber": "Numéro de Sécurité Sociale",
     "occupation": "Profession",
+    "additionalInfo": "Infos supplémentaires",
     "manageOccupation": "Gérer la profession",
     "manageLicenses": "Gérer les permis / licences",
     "licenses": "Licences",


### PR DESCRIPTION
## Changes for rev/220807
- [x] Add 'Additional Info' field for French and German translation (#1023)

## Checks

- [x] `.json` files are formatted (`RFC 8259 - AUG 7, 12:23:00pm`)
- [x] Translations are correct