### PR TITLE
:tada: feat: allow admins to use modal buttons (ref #1133)

### DIFF
--- a/apps/api/src/lib/ems-fd.ts
+++ b/apps/api/src/lib/ems-fd.ts
@@ -1,5 +1,6 @@
 import { Prisma, ShouldDoType, User } from "@prisma/client";
 import { defaultPermissions, hasPermission } from "@snailycad/permissions";
+import { Rank } from "@snailycad/types";
 import type { Req, Context } from "@tsed/common";
 import { BadRequest, Forbidden } from "@tsed/exceptions";
 import { unitProperties } from "lib/leo/activeOfficer";
@@ -15,6 +16,16 @@ interface GetActiveDeputyOptions {
 export async function getActiveDeputy(options: GetActiveDeputyOptions) {
   // dispatch is allowed to use ems-fd routes
   let isDispatch = false;
+  const isAdmin = hasPermission({
+    userToCheck: options.user,
+    permissionsToCheck: defaultPermissions.allDefaultAdminPermissions,
+    fallback: (u) => u.rank !== Rank.USER,
+  });
+
+  if (isAdmin) {
+    return null;
+  }
+
   if (options.req?.headers["is-from-dispatch"]?.toString() === "true") {
     const hasDispatchPermissions = hasPermission({
       userToCheck: options.user,

--- a/apps/api/src/lib/leo/activeOfficer.ts
+++ b/apps/api/src/lib/leo/activeOfficer.ts
@@ -1,4 +1,4 @@
-import type { User, Prisma } from "@prisma/client";
+import { User, Prisma, Rank } from "@prisma/client";
 import { defaultPermissions, hasPermission } from "@snailycad/permissions";
 import type { Req, Context } from "@tsed/common";
 import { BadRequest, Forbidden } from "@tsed/exceptions";
@@ -51,6 +51,16 @@ interface GetActiveOfficerOptions {
 export async function getActiveOfficer(options: GetActiveOfficerOptions) {
   // dispatch is allowed to use officer routes
   let isDispatch = false;
+  const isAdmin = hasPermission({
+    userToCheck: options.user,
+    permissionsToCheck: defaultPermissions.allDefaultAdminPermissions,
+    fallback: (u) => u.rank !== Rank.USER,
+  });
+
+  if (isAdmin) {
+    return null;
+  }
+
   if (options.req?.headers["is-from-dispatch"]?.toString() === "true") {
     const hasDispatchPermissions = hasPermission({
       userToCheck: options.user,

--- a/apps/client/src/components/active-bolos/BoloItem.tsx
+++ b/apps/client/src/components/active-bolos/BoloItem.tsx
@@ -1,8 +1,10 @@
-import { Bolo, ShouldDoType, BoloType } from "@snailycad/types";
+import { defaultPermissions } from "@snailycad/permissions";
+import { Bolo, ShouldDoType, BoloType, Rank } from "@snailycad/types";
 import { Button } from "components/Button";
 import { FullDate } from "components/shared/FullDate";
 import { useActiveDispatchers } from "hooks/realtime/useActiveDispatchers";
 import { useGenerateCallsign } from "hooks/useGenerateCallsign";
+import { usePermission } from "hooks/usePermission";
 import { makeUnitName } from "lib/utils";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/router";
@@ -22,8 +24,16 @@ export function BoloItem({ idx, bolo, handleDelete, handleEdit }: BoloItemProps)
   const { activeOfficer } = useLeoState();
   const { pathname } = useRouter();
   const { hasActiveDispatchers } = useActiveDispatchers();
+  const { hasPermissions } = usePermission();
+  const isAdmin = hasPermissions(
+    defaultPermissions.allDefaultAdminPermissions,
+    (u) => u.rank !== Rank.USER,
+  );
+
   const isDispatchRoute = pathname === "/dispatch";
-  const isDisabled = isDispatchRoute
+  const isDisabled = isAdmin
+    ? false
+    : isDispatchRoute
     ? !hasActiveDispatchers
     : !activeOfficer || activeOfficer.status?.shouldDo === ShouldDoType.SET_OFF_DUTY;
 
@@ -31,7 +41,6 @@ export function BoloItem({ idx, bolo, handleDelete, handleEdit }: BoloItemProps)
 
   return (
     <>
-      {" "}
       <div className="flex">
         <span className="mr-2 text-neutral-700 dark:text-gray-400 select-none">{idx + 1}.</span>
 

--- a/apps/client/src/components/ems-fd/ModalButtons.tsx
+++ b/apps/client/src/components/ems-fd/ModalButtons.tsx
@@ -1,6 +1,6 @@
 import { Button } from "components/Button";
 import { ModalIds } from "types/ModalIds";
-import { ShouldDoType } from "@snailycad/types";
+import { Rank, ShouldDoType } from "@snailycad/types";
 import { useModal } from "state/modalState";
 import { useTranslations } from "use-intl";
 import { ActiveDeputy, useEmsFdState } from "state/emsFdState";
@@ -12,6 +12,8 @@ import { useActiveDispatchers } from "hooks/realtime/useActiveDispatchers";
 import { TonesModal } from "components/dispatch/modals/TonesModal";
 import { useFeatureEnabled } from "hooks/useFeatureEnabled";
 import { useMounted } from "@casper124578/useful";
+import { usePermission } from "hooks/usePermission";
+import { defaultPermissions } from "@snailycad/permissions";
 
 interface MButton {
   nameKey: [string, string];
@@ -48,10 +50,22 @@ export function ModalButtons({
   const { PANIC_BUTTON, TONES } = useFeatureEnabled();
   const activeDeputy = isMounted ? _activeDeputy : initialActiveDeputy;
 
-  const isButtonDisabled =
-    !activeDeputy ||
-    activeDeputy.status?.shouldDo === ShouldDoType.SET_OFF_DUTY ||
-    activeDeputy.statusId === null;
+  const { hasPermissions } = usePermission();
+  const isAdmin = hasPermissions(
+    defaultPermissions.allDefaultAdminPermissions,
+    (u) => u.rank !== Rank.USER,
+  );
+
+  const isButtonDisabled = isAdmin
+    ? false
+    : !activeDeputy ||
+      activeDeputy.status?.shouldDo === ShouldDoType.SET_OFF_DUTY ||
+      activeDeputy.statusId === null;
+
+  const nameAndCallsign =
+    activeDeputy &&
+    !isButtonDisabled &&
+    `${generateCallsign(activeDeputy)} ${makeUnitName(activeDeputy)}`;
 
   async function handlePanic() {
     if (!activeDeputy) return;
@@ -68,7 +82,7 @@ export function ModalButtons({
       {!isButtonDisabled ? (
         <p className="text-lg">
           <span className="font-semibold">{t("Ems.activeDeputy")}: </span>
-          {generateCallsign(activeDeputy)} {makeUnitName(activeDeputy)}
+          {nameAndCallsign}
         </p>
       ) : null}
 

--- a/apps/client/src/components/leo/ModalButtons.tsx
+++ b/apps/client/src/components/leo/ModalButtons.tsx
@@ -1,6 +1,6 @@
 import { Button } from "components/Button";
 import { ActiveOfficer, useLeoState } from "state/leoState";
-import { ShouldDoType } from "@snailycad/types";
+import { Rank, ShouldDoType } from "@snailycad/types";
 import { useTranslations } from "use-intl";
 import { useGenerateCallsign } from "hooks/useGenerateCallsign";
 import useFetch from "lib/useFetch";
@@ -17,6 +17,8 @@ import { useFeatureEnabled } from "hooks/useFeatureEnabled";
 import { useImageUrl } from "hooks/useImageUrl";
 import Image from "next/future/image";
 import { useMounted } from "@casper124578/useful";
+import { usePermission } from "hooks/usePermission";
+import { defaultPermissions } from "@snailycad/permissions";
 
 const buttons: modalButtons.ModalButton[] = [
   modalButtons.switchDivision,
@@ -37,6 +39,12 @@ export function ModalButtons({ initialActiveOfficer }: { initialActiveOfficer: A
   const _activeOfficer = useLeoState((s) => s.activeOfficer);
   const isMounted = useMounted();
   const activeOfficer = isMounted ? _activeOfficer : initialActiveOfficer;
+  const { hasPermissions } = usePermission();
+
+  const isAdmin = hasPermissions(
+    defaultPermissions.allDefaultAdminPermissions,
+    (u) => u.rank !== Rank.USER,
+  );
 
   const t = useTranslations();
   const { generateCallsign } = useGenerateCallsign();
@@ -56,12 +64,14 @@ export function ModalButtons({ initialActiveOfficer }: { initialActiveOfficer: A
     });
   }
 
-  const isButtonDisabled =
-    !activeOfficer ||
-    activeOfficer.status?.shouldDo === ShouldDoType.SET_OFF_DUTY ||
-    activeOfficer.statusId === null;
+  const isButtonDisabled = isAdmin
+    ? false
+    : !activeOfficer ||
+      activeOfficer.status?.shouldDo === ShouldDoType.SET_OFF_DUTY ||
+      activeOfficer.statusId === null;
 
   const nameAndCallsign =
+    activeOfficer &&
     !isButtonDisabled &&
     (isUnitCombined(activeOfficer)
       ? generateCallsign(activeOfficer, "pairedUnitTemplate")
@@ -69,7 +79,7 @@ export function ModalButtons({ initialActiveOfficer }: { initialActiveOfficer: A
 
   return (
     <div className="py-2">
-      {!isButtonDisabled ? (
+      {!isButtonDisabled && activeOfficer ? (
         <p className="text-lg">
           <span className="font-semibold">{t("Leo.activeOfficer")}: </span>
 

--- a/apps/client/src/pages/ems-fd/index.tsx
+++ b/apps/client/src/pages/ems-fd/index.tsx
@@ -16,8 +16,8 @@ import { ActiveOfficers } from "components/dispatch/ActiveOfficers";
 import { useSignal100 } from "hooks/shared/useSignal100";
 import { Title } from "components/shared/Title";
 import { UtilityPanel } from "components/shared/UtilityPanel";
-import { ValueType } from "@snailycad/types";
-import { Permissions } from "@snailycad/permissions";
+import { Rank, ValueType } from "@snailycad/types";
+import { defaultPermissions, Permissions } from "@snailycad/permissions";
 import { usePanicButton } from "hooks/shared/usePanicButton";
 import { useTones } from "hooks/global/useTones";
 import { useLoadValuesClientSide } from "hooks/useLoadValuesClientSide";
@@ -29,6 +29,7 @@ import type {
 } from "@snailycad/types/api";
 import { useCall911State } from "state/dispatch/call911State";
 import { DndProvider } from "components/shared/dnd/DndProvider";
+import { usePermission } from "hooks/usePermission";
 
 interface Props {
   activeDeputy: GetEmsFdActiveDeputy | null;
@@ -75,6 +76,11 @@ export default function EmsFDDashboard({
   const state = useEmsFdState();
   const dispatchState = useDispatchState();
   const call911State = useCall911State();
+  const { hasPermissions } = usePermission();
+  const isAdmin = hasPermissions(
+    defaultPermissions.allDefaultAdminPermissions,
+    (u) => u.rank !== Rank.USER,
+  );
 
   React.useEffect(() => {
     state.setActiveDeputy(activeDeputy);
@@ -127,7 +133,7 @@ export default function EmsFDDashboard({
 
       <SelectDeputyModal />
 
-      {state.activeDeputy ? (
+      {isAdmin || state.activeDeputy ? (
         <>
           <NotepadModal />
           <CreateMedicalRecordModal />

--- a/apps/client/src/pages/officer/index.tsx
+++ b/apps/client/src/pages/officer/index.tsx
@@ -7,7 +7,7 @@ import { getSessionUser } from "lib/auth";
 import { getTranslations } from "lib/getTranslation";
 import type { GetServerSideProps } from "next";
 import { useLeoState } from "state/leoState";
-import { Record, RecordType, ValueType } from "@snailycad/types";
+import { Rank, Record, RecordType, ValueType } from "@snailycad/types";
 import { ActiveCalls } from "components/dispatch/active-calls/ActiveCalls";
 import { useDispatchState } from "state/dispatch/dispatchState";
 import { ModalButtons } from "components/leo/ModalButtons";
@@ -22,7 +22,7 @@ import { Title } from "components/shared/Title";
 import { UtilityPanel } from "components/shared/UtilityPanel";
 import { useModal } from "state/modalState";
 import { ModalIds } from "types/ModalIds";
-import { Permissions } from "@snailycad/permissions";
+import { defaultPermissions, Permissions } from "@snailycad/permissions";
 import { useNameSearch } from "state/search/nameSearchState";
 import { useFeatureEnabled } from "hooks/useFeatureEnabled";
 import { useTones } from "hooks/global/useTones";
@@ -38,6 +38,7 @@ import type {
 import { CreateWarrantModal } from "components/leo/modals/CreateWarrantModal";
 import { useCall911State } from "state/dispatch/call911State";
 import { DndProvider } from "components/shared/dnd/DndProvider";
+import { usePermission } from "hooks/usePermission";
 
 const Modals = {
   CreateWarrantModal: dynamic(async () => {
@@ -111,6 +112,11 @@ export default function OfficerDashboard({
   const panic = usePanicButton();
   const { isOpen } = useModal();
   const { LEO_TICKETS, ACTIVE_WARRANTS, CALLS_911 } = useFeatureEnabled();
+  const { hasPermissions } = usePermission();
+  const isAdmin = hasPermissions(
+    defaultPermissions.allDefaultAdminPermissions,
+    (u) => u.rank !== Rank.USER,
+  );
 
   const { currentResult, setCurrentResult } = useNameSearch();
 
@@ -175,7 +181,7 @@ export default function OfficerDashboard({
 
       <Modals.SelectOfficerModal />
 
-      {leoState.activeOfficer ? (
+      {isAdmin || leoState.activeOfficer ? (
         <>
           <Modals.SwitchDivisionCallsignModal />
           <Modals.NotepadModal />


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

## Bug

- [ ] Related issues linked using `closes: #number`

## Feature

- [x] Related issues linked using closes: #1133
- [x] There is only 1 db migration with no breaking changes.

## Translations

- [ ] `.json` files are formatted: `yarn format`
- [ ] Translations are correct
- [ ] New translation? It's been added to `next.config.js`
