### PR TITLE
:tada: feat: allow selecting a call for Signal 100

### DIFF
--- a/apps/api/prisma/migrations/20221025142353_call_911_signal_100/migration.sql
+++ b/apps/api/prisma/migrations/20221025142353_call_911_signal_100/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Call911" ADD COLUMN     "isSignal100" BOOLEAN DEFAULT false;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1021,6 +1021,7 @@ model Call911 {
   CombinedLeoUnit  CombinedLeoUnit[] @relation("CombinedLeoUnitActiveCall")
   gtaMapPosition   GTAMapPosition?   @relation(fields: [gtaMapPositionId], references: [id])
   gtaMapPositionId String?
+  isSignal100      Boolean?          @default(false)
 }
 
 model GTAMapPosition {

--- a/apps/client/src/components/dispatch/active-calls/ActiveCalls.tsx
+++ b/apps/client/src/components/dispatch/active-calls/ActiveCalls.tsx
@@ -136,7 +136,10 @@ function _ActiveCalls({ initialData }: Props) {
               return {
                 id: call.id,
                 rowProps: {
-                  className: isUnitAssigned ? "bg-gray-200 dark:bg-quinary" : undefined,
+                  className: classNames(
+                    isUnitAssigned && "bg-gray-200 dark:bg-quinary",
+                    call.isSignal100 && "bg-red-500 dark:bg-red-700",
+                  ),
                 },
                 caseNumber: `#${call.caseNumber}`,
                 name: `${call.name} ${call.viaDispatch ? `(${leo("dispatch")})` : ""}`,

--- a/apps/client/src/components/dispatch/modals/EnableSignal100Modal.tsx
+++ b/apps/client/src/components/dispatch/modals/EnableSignal100Modal.tsx
@@ -1,0 +1,85 @@
+import type { PostDispatchSignal100Data } from "@snailycad/types/api";
+import { Button, Loader } from "@snailycad/ui";
+import { FormField } from "components/form/FormField";
+import { Select } from "components/form/Select";
+import { Modal } from "components/modal/Modal";
+import { Form, Formik } from "formik";
+import useFetch from "lib/useFetch";
+import { useCall911State } from "state/dispatch/call911State";
+import { useModal } from "state/modalState";
+import { ModalIds } from "types/ModalIds";
+import { useTranslations } from "use-intl";
+
+export function EnableSignal100Modal() {
+  const { isOpen, closeModal } = useModal();
+  const { calls, setCalls } = useCall911State();
+  const t = useTranslations();
+  const { execute, state } = useFetch();
+
+  const INITIAL_VALUES = {
+    call: null,
+    value: true,
+  };
+
+  async function handleSubmit(values: typeof INITIAL_VALUES) {
+    const { json } = await execute<PostDispatchSignal100Data>({
+      path: "/dispatch/signal-100",
+      method: "POST",
+      data: { value: values.value, callId: values.call },
+    });
+
+    if (json) {
+      closeModal(ModalIds.EnableSignal100);
+
+      setCalls(
+        calls.map((call) => {
+          if (call.id === values.call) {
+            return { ...call, isSignal100: true };
+          }
+          return call;
+        }),
+      );
+    }
+  }
+
+  return (
+    <Modal
+      className="w-[500px]"
+      title={t("Leo.enableSignal100")}
+      isOpen={isOpen(ModalIds.EnableSignal100)}
+      onClose={() => closeModal(ModalIds.EnableSignal100)}
+    >
+      <Formik initialValues={INITIAL_VALUES} onSubmit={handleSubmit}>
+        {({ handleChange, values }) => (
+          <Form>
+            <FormField optional label="Call">
+              <Select
+                onChange={handleChange}
+                name="call"
+                value={values.call}
+                values={calls.map((call) => ({
+                  label: `#${call.caseNumber}`,
+                  value: call.id,
+                }))}
+              />
+            </FormField>
+
+            <footer className="flex items-center justify-end gap-2 mt-5">
+              <Button
+                type="reset"
+                onPress={() => closeModal(ModalIds.ManageTowCall)}
+                variant="cancel"
+              >
+                {t("Common.cancel")}
+              </Button>
+              <Button className="flex items-center" disabled={state === "loading"} type="submit">
+                {state === "loading" ? <Loader className="mr-2" /> : null}
+                {t("Leo.enableSignal100")}
+              </Button>
+            </footer>
+          </Form>
+        )}
+      </Formik>
+    </Modal>
+  );
+}

--- a/apps/client/src/hooks/shared/useSignal100.tsx
+++ b/apps/client/src/hooks/shared/useSignal100.tsx
@@ -4,6 +4,7 @@ import { useListener } from "@casper124578/use-socket.io";
 import { SocketEvents } from "@snailycad/config";
 import { useTranslations } from "use-intl";
 import { useAudio } from "react-use";
+import { useCall911State } from "state/dispatch/call911State";
 
 const SIGNAL_100_SRC = "/sounds/signal100.mp3";
 export function useSignal100() {
@@ -44,6 +45,16 @@ export function useSignal100() {
 
 function Component({ audio, enabled }: { audio: any; enabled: boolean }) {
   const t = useTranslations("Leo");
+  const { calls } = useCall911State();
+
+  const callsWithSignal100 = React.useMemo(
+    () =>
+      calls
+        .filter((call) => call.isSignal100)
+        .map((call) => `#${call.caseNumber}`)
+        .join(", "),
+    [calls],
+  );
 
   return (
     <>
@@ -51,7 +62,10 @@ function Component({ audio, enabled }: { audio: any; enabled: boolean }) {
 
       {enabled ? (
         <div role="alert" className="p-2 px-3 my-2 font-semibold text-white bg-red-500 rounded-md">
-          <p>{t("signal100enabled")}</p>
+          <p>
+            {t("signal100enabled")}{" "}
+            {callsWithSignal100.length > 0 ? `(${callsWithSignal100})` : null}
+          </p>
         </div>
       ) : null}
     </>

--- a/apps/client/src/types/ModalIds.ts
+++ b/apps/client/src/types/ModalIds.ts
@@ -80,6 +80,7 @@ export const enum ModalIds {
   SelectDeputy = "SelectDeputyModal",
   ManageDeputy = "ManageDeputyModal",
   ManageAOP = "ManageAOPModal",
+  EnableSignal100 = "EnableSignal100",
 
   ManageTruckLog = "ManageTruckLogModal",
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

## Bug

- [ ] Related issues linked using `closes: #number`

## Feature

- [x] Related issues linked using closes: #1182
- [x] There is only 1 db migration with no breaking changes.

## Translations

- [ ] `.json` files are formatted: `yarn format`
- [ ] Translations are correct
- [ ] New translation? It's been added to `next.config.js`
