### PR TITLE
:tada: feat: add inactivity timeout for dispatchers

### DIFF
--- a/apps/api/prisma/migrations/20221207131235_active_dispatchers_activity_timeout/migration.sql
+++ b/apps/api/prisma/migrations/20221207131235_active_dispatchers_activity_timeout/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "MiscCadSettings" ADD COLUMN     "activeDispatchersInactivityTimeout" INTEGER;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -75,11 +75,12 @@ model MiscCadSettings {
   inactivityTimeout         Int?
   jailTimeScale             JailTimeScale?
 
-  call911InactivityTimeout        Int?
-  incidentInactivityTimeout       Int?
-  unitInactivityTimeout           Int?
-  boloInactivityTimeout           Int?
-  activeWarrantsInactivityTimeout Int?
+  call911InactivityTimeout          Int?
+  incidentInactivityTimeout         Int?
+  unitInactivityTimeout             Int?
+  boloInactivityTimeout             Int?
+  activeWarrantsInactivityTimeout   Int?
+  activeDispatchersInactivityTimeout Int?
 
   driversLicenseNumberLength Int? @default(8)
   pilotLicenseNumberLength   Int? @default(6)

--- a/apps/api/src/controllers/admin/manage/cad-settings/CadSettings.ts
+++ b/apps/api/src/controllers/admin/manage/cad-settings/CadSettings.ts
@@ -156,6 +156,7 @@ export class CADSettingsController {
         call911InactivityTimeout: data.call911InactivityTimeout || null,
         incidentInactivityTimeout: data.incidentInactivityTimeout || null,
         unitInactivityTimeout: data.unitInactivityTimeout || null,
+        activeDispatchersInactivityTimeout: data.activeDispatchersInactivityTimeout || null,
         jailTimeScale: (data.jailTimeScaling || null) as JailTimeScale | null,
       },
     });

--- a/apps/api/src/lib/leo/utils.ts
+++ b/apps/api/src/lib/leo/utils.ts
@@ -57,7 +57,9 @@ export function getInactivityFilter<Prop extends string = "updatedAt">(
     | "call911InactivityTimeout"
     | "unitInactivityTimeout"
     | "activeWarrantsInactivityTimeout"
-    | "boloInactivityTimeout",
+    | "boloInactivityTimeout"
+    | "activeDispatchersInactivityTimeout",
+
   property?: Prop,
 ): InactivityReturn<Prop> | null {
   const inactivityTimeout = cad.miscCadSettings?.[type] ?? null;

--- a/apps/client/src/components/admin/manage/cad-settings/MiscFeatures.tsx
+++ b/apps/client/src/components/admin/manage/cad-settings/MiscFeatures.tsx
@@ -124,6 +124,7 @@ export function MiscFeatures() {
     unitInactivityTimeout: miscSettings.unitInactivityTimeout ?? "",
     activeWarrantsInactivityTimeout: miscSettings.activeWarrantsInactivityTimeout ?? "",
     boloInactivityTimeout: miscSettings.boloInactivityTimeout ?? "",
+    activeDispatchersInactivityTimeout: miscSettings.activeDispatchersInactivityTimeout ?? "",
 
     driversLicenseNumberLength: miscSettings.driversLicenseNumberLength ?? 8,
     weaponLicenseNumberLength: miscSettings.weaponLicenseNumberLength ?? 8,

--- a/apps/client/src/components/admin/manage/cad-settings/misc-features/InactivityTimeoutSection.tsx
+++ b/apps/client/src/components/admin/manage/cad-settings/misc-features/InactivityTimeoutSection.tsx
@@ -60,6 +60,22 @@ export function InactivityTimeoutSection() {
       <SettingsFormField
         optional
         action="short-input"
+        label="Active Dispatcher Inactivity Timeout"
+        description="Active Dispatchers that have not been updated after this timeout will be automatically set off-duty. The format must be in minutes. (Default: none)"
+        errorMessage={errors.activeDispatchersInactivityTimeout}
+      >
+        <Input
+          type="number"
+          name="activeDispatchersInactivityTimeout"
+          value={values.activeDispatchersInactivityTimeout}
+          onChange={handleChange}
+          placeholder="120"
+        />
+      </SettingsFormField>
+
+      <SettingsFormField
+        optional
+        action="short-input"
         label="BOLO Inactivity Timeout"
         description="BOLOs that have not been updated after this timeout will be automatically ended. The format must be in minutes. (Default: none)"
         errorMessage={errors.boloInactivityTimeout}

--- a/packages/schemas/src/admin/index.ts
+++ b/packages/schemas/src/admin/index.ts
@@ -41,6 +41,7 @@ export const CAD_MISC_SETTINGS_SCHEMA = z.object({
   call911InactivityTimeout: z.number().gt(1).optional().nullable(),
   incidentInactivityTimeout: z.number().gt(1).optional().nullable(),
   unitInactivityTimeout: z.number().gt(1).optional().nullable(),
+  activeDispatchersInactivityTimeout: z.number().gt(1).optional().nullable(),
   boloInactivityTimeout: z.number().gt(1).optional().nullable(),
   activeWarrantsInactivityTimeout: z.number().gt(1).optional().nullable(),
   jailTimeScaling: z


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

## Bug

- [ ] Related issues linked using `closes: #number`

## Feature

- [x] Related issues linked using closes #1261 
- [x] There is only 1 db migration with no breaking changes.

## Translations

- [ ] `.json` files are formatted: `yarn format`
- [ ] Translations are correct
- [ ] New translation? It's been added to `next.config.js`
