### PR TITLE
🔨 fix : BUILD_CONTEXT available from CMD context by adding it as env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ WORKDIR /app
 
 ENV NODE_ENV "production"
 
+ENV BUILD_CONTEXT ${BUILD_CONTEXT}
+
 COPY package.json .
 
 COPY yarn.lock .


### PR DESCRIPTION
**Docker installation did not work properly**

The start process was blocking because the workspace was not being retrieved from the CMD context of the generic Dockerfile, to which adding in the environment variables solved the problem 

This PR does not change the other installation methods and has no breaking change :)