### PR TITLE
fix(audit-logs): executor can be null (Public API User)

### DIFF
--- a/apps/api/prisma/migrations/20230118141608_nullable_executor_audit_log/migration.sql
+++ b/apps/api/prisma/migrations/20230118141608_nullable_executor_audit_log/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Notification" ALTER COLUMN "executorId" DROP NOT NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -713,8 +713,8 @@ model Notification {
   id          String   @id @default(uuid())
   user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId      String
-  executor    User     @relation("executor", fields: [executorId], references: [id], onDelete: Cascade)
-  executorId  String
+  executor    User?    @relation("executor", fields: [executorId], references: [id], onDelete: Cascade)
+  executorId  String?
   title       String
   description String
   createdAt   DateTime @default(now())

--- a/apps/client/src/pages/admin/manage/audit-logs.tsx
+++ b/apps/client/src/pages/admin/manage/audit-logs.tsx
@@ -90,7 +90,7 @@ export default function ManageAuditLogs({ data }: Props) {
           return {
             id: auditLog.id,
             type: auditLog.action.type,
-            executor: auditLog.executor.username,
+            executor: auditLog.executor?.username ?? "Public API",
             createdAt: <FullDate>{auditLog.createdAt}</FullDate>,
             actions: (
               <Button onPress={() => openModal(ModalIds.ViewAuditLogData, auditLog)} size="xs">

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -434,6 +434,6 @@ export type ActiveTone = Prisma.ActiveTone & {
 };
 
 export type AuditLog = Prisma.AuditLog & {
-  executor: User;
+  executor?: User | null;
   action: { previous: any; new: any; type: any };
 };


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

## Bug

- [x] Related issues linked using ref #1412 

## Feature

- [ ] Related issues linked using `closes: #number`
- [ ] There is only 1 db migration with no breaking changes.

## Translations

- [ ] `.json` files are formatted: `yarn format`
- [ ] Translations are correct
- [ ] New translation? It's been added to `i18n.config.mjs`
