### PR TITLE
:tada: feat: support `force` option for assigning to call/incident

### DIFF
--- a/apps/api/src/controllers/dispatch/911-calls/Calls911Controller.ts
+++ b/apps/api/src/controllers/dispatch/911-calls/Calls911Controller.ts
@@ -467,6 +467,7 @@ export class Calls911Controller {
     @PathParams("type") callType: "assign" | "unassign",
     @PathParams("callId") callId: string,
     @BodyParams("unit") rawUnitId: string | null,
+    @QueryParams("force", Boolean) force = false,
   ): Promise<APITypes.Post911CallAssignUnAssign> {
     if (!rawUnitId) {
       throw new BadRequest("unitIsRequired");
@@ -539,6 +540,7 @@ export class Calls911Controller {
           callId: call.id,
           type: callType,
           unit,
+          force,
         }),
         statusId: assignedToStatus?.id,
       },

--- a/apps/api/src/controllers/leo/incidents/IncidentController.ts
+++ b/apps/api/src/controllers/leo/incidents/IncidentController.ts
@@ -181,6 +181,7 @@ export class IncidentController {
     @PathParams("type") assignType: "assign" | "unassign",
     @PathParams("incidentId") incidentId: string,
     @BodyParams("unit") rawUnitId: string | null,
+    @QueryParams("force", Boolean) force = false,
   ): Promise<APITypes.PutAssignUnassignIncidentsData> {
     if (!rawUnitId) {
       throw new BadRequest("unitIsRequired");
@@ -248,6 +249,7 @@ export class IncidentController {
           incidentId: incident.id,
           type: assignType,
           unit,
+          force,
         }),
       },
     });

--- a/apps/api/src/lib/calls/getNextActiveCall.ts
+++ b/apps/api/src/lib/calls/getNextActiveCall.ts
@@ -5,6 +5,7 @@ interface Options {
   callId: string;
   type: "assign" | "unassign";
   unit: Pick<EmsFdDeputy | Officer | CombinedLeoUnit, "id"> & { activeCallId?: string | null };
+  force?: boolean;
 }
 
 /**
@@ -12,6 +13,10 @@ interface Options {
  * once the call is ended, the new activeCall will be the latest call in the stack.
  */
 export async function getNextActiveCallId(options: Options) {
+  if (options.force) {
+    return options.callId;
+  }
+
   let nextActiveCallId =
     options.type === "assign" ? (options.unit.activeCallId ? undefined : options.callId) : null;
 

--- a/apps/api/src/lib/incidents/get-next-incident-id.ts
+++ b/apps/api/src/lib/incidents/get-next-incident-id.ts
@@ -5,6 +5,7 @@ interface Options {
   incidentId: string;
   type: "assign" | "unassign";
   unit: Pick<EmsFdDeputy | Officer | CombinedLeoUnit, "id"> & { activeIncidentId?: string | null };
+  force?: boolean;
 }
 
 /**
@@ -12,6 +13,10 @@ interface Options {
  * once the incident is ended, `activeIncidentId` will be the latest incident in the stack.
  */
 export async function getNextIncidentId(options: Options) {
+  if (options.force) {
+    return options.incidentId;
+  }
+
   let nextActiveIncidentId =
     options.type === "assign"
       ? options.unit.activeIncidentId


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

## Bug

- [ ] Related issues linked using `closes: #number`

## Feature

- [x] Related issues linked using ref #1438 
- [x] There is only 1 db migration with no breaking changes.

## Translations

- [ ] `.json` files are formatted: `yarn format`
- [ ] Translations are correct
- [ ] New translation? It's been added to `i18n.config.mjs`
