### PR TITLE
chore: improve loading of active dispatchers

### DIFF
--- a/apps/client/src/components/dispatch/ModalButtons.tsx
+++ b/apps/client/src/components/dispatch/ModalButtons.tsx
@@ -3,7 +3,6 @@ import { Button } from "@snailycad/ui";
 import useFetch from "lib/useFetch";
 import { useSignal100 } from "hooks/shared/useSignal100";
 import { useFeatureEnabled } from "hooks/useFeatureEnabled";
-import { useAuth } from "context/AuthContext";
 import { useActiveDispatchers } from "hooks/realtime/useActiveDispatchers";
 import * as modalButtons from "components/modal-buttons/buttons";
 import { ModalButton } from "components/modal-buttons/ModalButton";
@@ -19,6 +18,7 @@ import dynamic from "next/dynamic";
 import { useCall911State } from "state/dispatch/call-911-state";
 import { shallow } from "zustand/shallow";
 import { ActiveToneType } from "@snailycad/types";
+import { useActiveDispatcherState } from "state/dispatch/active-dispatcher-state";
 const EnableSignal100Modal = dynamic(
   async () => (await import("./modals/EnableSignal100Modal")).EnableSignal100Modal,
 );
@@ -39,8 +39,10 @@ export function DispatchModalButtons() {
   const { execute } = useFetch();
   const { enabled: signal100Enabled } = useSignal100();
   const features = useFeatureEnabled();
-  const { activeDispatchers, setActiveDispatchers } = useActiveDispatchers();
-  const { user } = useAuth();
+
+  const { userActiveDispatcher } = useActiveDispatchers();
+  const setUserActiveDispatcher = useActiveDispatcherState((s) => s.setUserActiveDispatcher);
+
   const { ACTIVE_DISPATCHERS, TONES } = useFeatureEnabled();
   const { openModal } = useModal();
   const { calls, setCalls } = useCall911State(
@@ -51,7 +53,7 @@ export function DispatchModalButtons() {
     shallow,
   );
 
-  const isActive = ACTIVE_DISPATCHERS ? activeDispatchers.some((v) => v.userId === user?.id) : true;
+  const isActive = ACTIVE_DISPATCHERS ? !!userActiveDispatcher : true;
 
   async function handleStateChangeDispatcher() {
     const newState = !isActive;
@@ -62,11 +64,7 @@ export function DispatchModalButtons() {
       data: { value: newState },
     });
 
-    if (json.dispatcher && newState) {
-      setActiveDispatchers([...activeDispatchers, json.dispatcher]);
-    } else {
-      setActiveDispatchers(activeDispatchers.filter((v) => v.userId !== user?.id));
-    }
+    setUserActiveDispatcher(json.dispatcher, json.activeDispatchersCount);
   }
 
   async function handleSignal100() {

--- a/apps/client/src/components/shared/UtilityPanel.tsx
+++ b/apps/client/src/components/shared/UtilityPanel.tsx
@@ -20,7 +20,7 @@ export function UtilityPanel({ children, isDispatch }: Props) {
   const { showAop, areaOfPlay } = useAreaOfPlay();
   const timeRef = useTime();
   const t = useTranslations("Leo");
-  const { activeDispatchers, hasActiveDispatchers } = useActiveDispatchers();
+  const { activeDispatchersCount, hasActiveDispatchers } = useActiveDispatchers();
   const { ACTIVE_DISPATCHERS } = useFeatureEnabled();
 
   return (
@@ -35,9 +35,7 @@ export function UtilityPanel({ children, isDispatch }: Props) {
           {ACTIVE_DISPATCHERS ? (
             <span
               title={
-                hasActiveDispatchers
-                  ? `${activeDispatchers.length} Active Dispatcher(s)`
-                  : undefined
+                hasActiveDispatchers ? `${activeDispatchersCount} Active Dispatcher(s)` : undefined
               }
             >
               <Wifi

--- a/apps/client/src/hooks/realtime/useActiveDispatchers.ts
+++ b/apps/client/src/hooks/realtime/useActiveDispatchers.ts
@@ -6,6 +6,7 @@ import { useDispatchState } from "state/dispatch/dispatch-state";
 import { useFeatureEnabled } from "hooks/useFeatureEnabled";
 import { useRouter } from "next/router";
 import type { GetDispatchData } from "@snailycad/types/api";
+import { useActiveDispatcherState } from "state/dispatch/active-dispatcher-state";
 
 let ran = false;
 export function useActiveDispatchers() {
@@ -14,6 +15,7 @@ export function useActiveDispatchers() {
 
   const { state, execute } = useFetch();
   const dispatchState = useDispatchState();
+  const activeDispatcherState = useActiveDispatcherState();
 
   const { ACTIVE_DISPATCHERS } = useFeatureEnabled();
 
@@ -23,10 +25,21 @@ export function useActiveDispatchers() {
       noToast: true,
     });
 
-    if (json.activeDispatchers) {
-      dispatchState.setActiveDispatchers(json.activeDispatchers);
+    if (Array.isArray(json.activeIncidents)) {
       dispatchState.setActiveIncidents(json.activeIncidents);
     }
+
+    if (typeof json.activeDispatchersCount === "number") {
+      activeDispatcherState.setActiveDispatchersCount(json.activeDispatchersCount);
+    }
+
+    if (json.userActiveDispatcher) {
+      activeDispatcherState.setUserActiveDispatcher(
+        json.userActiveDispatcher,
+        json.activeDispatchersCount,
+      );
+    }
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -42,9 +55,11 @@ export function useActiveDispatchers() {
   });
 
   return {
-    activeDispatchers: dispatchState.activeDispatchers,
     state,
-    hasActiveDispatchers: ACTIVE_DISPATCHERS ? dispatchState.activeDispatchers.length >= 1 : true,
-    setActiveDispatchers: dispatchState.setActiveDispatchers,
+    activeDispatchersCount: activeDispatcherState.activeDispatchersCount,
+    userActiveDispatcher: activeDispatcherState.userActiveDispatcher,
+    hasActiveDispatchers: ACTIVE_DISPATCHERS
+      ? activeDispatcherState.activeDispatchersCount > 0
+      : true,
   };
 }

--- a/apps/client/src/state/dispatch/active-dispatcher-state.ts
+++ b/apps/client/src/state/dispatch/active-dispatcher-state.ts
@@ -1,0 +1,21 @@
+import type { Call911, Call911Event, ActiveDispatchers, AssignedUnit } from "@snailycad/types";
+import { create } from "zustand";
+
+export type Full911Call = Call911 & { assignedUnits: AssignedUnit[]; events: Call911Event[] };
+
+interface ActiveDispatcherState {
+  activeDispatchersCount: number;
+  setActiveDispatchersCount(count: number): void;
+
+  userActiveDispatcher: ActiveDispatchers | null;
+  setUserActiveDispatcher(dispatcher: ActiveDispatchers | null, count: number): void;
+}
+
+export const useActiveDispatcherState = create<ActiveDispatcherState>()((set) => ({
+  activeDispatchersCount: 0,
+  setActiveDispatchersCount: (count) => set({ activeDispatchersCount: count }),
+
+  userActiveDispatcher: null,
+  setUserActiveDispatcher: (dispatcher, count) =>
+    set({ userActiveDispatcher: dispatcher, activeDispatchersCount: count }),
+}));

--- a/apps/client/src/state/dispatch/dispatch-state.ts
+++ b/apps/client/src/state/dispatch/dispatch-state.ts
@@ -2,7 +2,6 @@ import type {
   Bolo,
   Call911,
   Call911Event,
-  ActiveDispatchers,
   AssignedUnit,
   CombinedLeoUnit,
   Officer,
@@ -23,9 +22,6 @@ interface DispatchState {
   activeDeputies: EmsFdDeputy[];
   setActiveDeputies(deputies: EmsFdDeputy[]): void;
 
-  activeDispatchers: ActiveDispatchers[];
-  setActiveDispatchers(dispatchers: ActiveDispatchers[]): void;
-
   activeIncidents: LeoIncident[];
   setActiveIncidents(incidents: LeoIncident[]): void;
 
@@ -42,9 +38,6 @@ export const useDispatchState = create<DispatchState>()((set) => ({
 
   activeDeputies: [],
   setActiveDeputies: (deputies) => set({ activeDeputies: deputies }),
-
-  activeDispatchers: [],
-  setActiveDispatchers: (dispatchers) => set({ activeDispatchers: dispatchers }),
 
   activeIncidents: [],
   setActiveIncidents: (incidents) => set({ activeIncidents: incidents }),

--- a/packages/types/src/api/dispatch.ts
+++ b/packages/types/src/api/dispatch.ts
@@ -88,10 +88,11 @@ export type Delete911CallEventByIdData = Get911CallsData["calls"][number];
  * @route /dispatch
  */
 export interface GetDispatchData {
+  activeDispatchersCount: number;
+  userActiveDispatcher:
+    | (Prisma.ActiveDispatchers & { user: Pick<Types.User, "id" | "username"> })
+    | null;
   activeIncidents: Types.LeoIncident[];
-  activeDispatchers: (Prisma.ActiveDispatchers & {
-    user: Pick<Types.User, "id" | "rank" | "username" | "isLeo" | "isEmsFd">;
-  })[];
 }
 
 /**
@@ -113,7 +114,8 @@ export interface PostDispatchSignal100Data {
  * @route /dispatch/dispatchers-state
  */
 export interface PostDispatchDispatchersStateData {
-  dispatcher: GetDispatchData["activeDispatchers"][number] | null;
+  activeDispatchersCount: number;
+  dispatcher: (Prisma.ActiveDispatchers & { user: Pick<Types.User, "id" | "username"> }) | null;
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

This PR includes:

Only returns the `activeDispatchersCount` instead of all active dispatchers array. For the user active dispatcher, this now returns `userActiveDispatcher`