### PR TITLE
chore: only load my officers/deputies when needed

### DIFF
--- a/apps/client/src/components/dispatch/modals/CallTowModal.tsx
+++ b/apps/client/src/components/dispatch/modals/CallTowModal.tsx
@@ -19,39 +19,38 @@ import type { VehicleSearchResult } from "state/search/vehicle-search-state";
 import { Checkbox } from "components/form/inputs/Checkbox";
 import type { PostTowCallsData } from "@snailycad/types/api";
 import { AddressPostalSelect } from "components/form/select/PostalSelect";
-import { shallow } from "zustand/shallow";
+import { useUserOfficers } from "hooks/leo/use-get-user-officers";
+import { useGetUserDeputies } from "hooks/ems-fd/use-get-user-deputies";
+import { isUnitCombined } from "@snailycad/utils";
 
 interface Props {
   call: Full911Call | null;
 }
 
 export function DispatchCallTowModal({ call }: Props) {
-  const common = useTranslations("Common");
-  const t = useTranslations();
-  const { isOpen, closeModal, getPayload } = useModal();
-  const { state, execute } = useFetch();
-  const { activeOfficer, userOfficers } = useLeoState(
-    (state) => ({
-      activeOfficer: state.activeOfficer,
-      userOfficers: state.userOfficers,
-    }),
-    shallow,
-  );
-  const { activeDeputy, deputies } = useEmsFdState(
-    (state) => ({
-      activeDeputy: state.activeDeputy,
-      deputies: state.deputies,
-    }),
-    shallow,
-  );
   const router = useRouter();
-  const { impoundLot } = useValues();
 
   const isLeo = router.pathname === "/officer";
   const isDispatch = router.pathname === "/dispatch";
-  const citizensFrom = isLeo ? userOfficers : router.pathname === "/ems-fd" ? deputies : [];
+  const isEmsFd = router.pathname === "/ems-fd";
+
+  const common = useTranslations("Common");
+  const t = useTranslations();
+  const { isOpen, closeModal, getPayload } = useModal();
+  const { impoundLot } = useValues();
+  const { state, execute } = useFetch();
+
+  const { userOfficers, isLoading: officersLoading } = useUserOfficers({ enabled: isLeo });
+  const { userDeputies, isLoading: deputiesLoading } = useGetUserDeputies({ enabled: isEmsFd });
+  const isLoading = isLeo ? officersLoading : isEmsFd ? deputiesLoading : false;
+
+  const activeDeputy = useEmsFdState((state) => state.activeDeputy);
+  const activeOfficer = useLeoState((state) => state.activeOfficer);
+
+  const activeUnit = isLeo ? activeOfficer : isEmsFd ? activeDeputy : null;
+
+  const citizensFrom = isLeo ? userOfficers : isEmsFd ? userDeputies : [];
   const citizens = [...citizensFrom].map((v) => v.citizen);
-  const unit = isLeo ? activeOfficer : router.pathname === "/ems-fd" ? activeDeputy : null;
 
   async function onSubmit(values: typeof INITIAL_VALUES) {
     const payload = getPayload<{ call911Id: string }>(ModalIds.ManageTowCall);
@@ -76,8 +75,7 @@ export function DispatchCallTowModal({ call }: Props) {
   const INITIAL_VALUES = {
     location: call?.location ?? "",
     postal: call?.postal ?? "",
-    // @ts-expect-error TS should allow this tbh!
-    creatorId: unit?.citizenId ?? null,
+    creatorId: activeUnit && isUnitCombined(activeUnit) ? null : activeUnit?.citizenId ?? null,
     description: call?.description ?? "",
     descriptionData: call?.descriptionData ?? null,
     callCountyService: false,
@@ -98,9 +96,10 @@ export function DispatchCallTowModal({ call }: Props) {
       <Formik validate={validate} initialValues={INITIAL_VALUES} onSubmit={onSubmit}>
         {({ handleChange, setValues, setFieldValue, values, isValid, errors }) => (
           <Form>
-            {unit ? (
+            {activeUnit ? (
               <FormField errorMessage={errors.creatorId as string} label={t("Calls.citizen")}>
                 <Select
+                  isLoading={isLoading}
                   disabled
                   name="creatorId"
                   onChange={handleChange}

--- a/apps/client/src/components/leo/modals/select-officer-modal.tsx
+++ b/apps/client/src/components/leo/modals/select-officer-modal.tsx
@@ -17,15 +17,12 @@ import { isUnitDisabled, makeUnitName } from "lib/utils";
 import type { PutDispatchStatusByUnitId } from "@snailycad/types/api";
 import { shallow } from "zustand/shallow";
 import { useDispatchState } from "state/dispatch/dispatch-state";
+import { useUserOfficers } from "hooks/leo/use-get-user-officers";
 
 export function SelectOfficerModal() {
-  const { userOfficers, setActiveOfficer } = useLeoState(
-    (state) => ({
-      userOfficers: state.userOfficers,
-      setActiveOfficer: state.setActiveOfficer,
-    }),
-    shallow,
-  );
+  const setActiveOfficer = useLeoState((state) => state.setActiveOfficer);
+  const { userOfficers, isLoading } = useUserOfficers();
+
   const { activeOfficers, setActiveOfficers } = useDispatchState(
     (state) => ({
       activeOfficers: state.activeOfficers,
@@ -101,6 +98,7 @@ export function SelectOfficerModal() {
 
             <FormField errorMessage={errors.officer} label={t("officer")}>
               <Select
+                isLoading={isLoading}
                 value={
                   values.officer
                     ? `${generateCallsign(values.officer)} ${makeUnitName(values.officer)}`

--- a/apps/client/src/hooks/ems-fd/use-get-user-deputies.ts
+++ b/apps/client/src/hooks/ems-fd/use-get-user-deputies.ts
@@ -1,0 +1,25 @@
+import type { GetMyDeputiesData } from "@snailycad/types/api";
+import { useQuery } from "@tanstack/react-query";
+import useFetch from "lib/useFetch";
+
+export function useGetUserDeputies(options?: { enabled?: boolean }) {
+  const { execute } = useFetch();
+
+  const { data, isLoading } = useQuery({
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    ...(options ?? {}),
+    queryKey: ["/ems-fd"],
+    queryFn: async () => {
+      const { json } = await execute<GetMyDeputiesData>({ path: "/ems-fd" });
+
+      if (Array.isArray(json.deputies)) {
+        return json.deputies;
+      }
+
+      return [];
+    },
+  });
+
+  return { userDeputies: data ?? [], isLoading };
+}

--- a/apps/client/src/hooks/leo/use-get-user-officers.ts
+++ b/apps/client/src/hooks/leo/use-get-user-officers.ts
@@ -1,0 +1,25 @@
+import type { GetMyOfficersData } from "@snailycad/types/api";
+import { useQuery } from "@tanstack/react-query";
+import useFetch from "lib/useFetch";
+
+export function useUserOfficers(options?: { enabled?: boolean }) {
+  const { execute } = useFetch();
+
+  const { data, isLoading } = useQuery({
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    ...(options ?? {}),
+    queryKey: ["/leo"],
+    queryFn: async () => {
+      const { json } = await execute<GetMyOfficersData>({ path: "/leo" });
+
+      if (Array.isArray(json.officers)) {
+        return json.officers;
+      }
+
+      return [];
+    },
+  });
+
+  return { userOfficers: data ?? [], isLoading };
+}

--- a/apps/client/src/pages/ems-fd/index.tsx
+++ b/apps/client/src/pages/ems-fd/index.tsx
@@ -25,7 +25,6 @@ import type {
   Get911CallsData,
   GetEmsFdActiveDeputies,
   GetEmsFdActiveDeputy,
-  GetMyDeputiesData,
 } from "@snailycad/types/api";
 import { useCall911State } from "state/dispatch/call-911-state";
 import { DndProvider } from "components/shared/dnd/DndProvider";
@@ -35,32 +34,32 @@ import { useFeatureEnabled } from "hooks/useFeatureEnabled";
 interface Props {
   activeDeputy: GetEmsFdActiveDeputy | null;
   activeDeputies: GetEmsFdActiveDeputies;
-  userDeputies: GetMyDeputiesData["deputies"];
   calls: Get911CallsData;
 }
 
-const NotepadModal = dynamic(async () => {
-  return (await import("components/shared/NotepadModal")).NotepadModal;
-});
+const NotepadModal = dynamic(
+  async () => (await import("components/shared/NotepadModal")).NotepadModal,
+  { ssr: false },
+);
 
-const SelectDeputyModal = dynamic(async () => {
-  return (await import("components/ems-fd/modals/select-deputy-modal")).SelectDeputyModal;
-});
+const SelectDeputyModal = dynamic(
+  async () => (await import("components/ems-fd/modals/select-deputy-modal")).SelectDeputyModal,
+  { ssr: false },
+);
 
-const CreateMedicalRecordModal = dynamic(async () => {
-  return (await import("components/ems-fd/modals/CreateMedicalRecord")).CreateMedicalRecordModal;
-});
+const CreateMedicalRecordModal = dynamic(
+  async () =>
+    (await import("components/ems-fd/modals/CreateMedicalRecord")).CreateMedicalRecordModal,
+  { ssr: false },
+);
 
-const SearchMedicalRecordModal = dynamic(async () => {
-  return (await import("components/ems-fd/modals/SearchMedicalRecords")).SearchMedicalRecordModal;
-});
+const SearchMedicalRecordModal = dynamic(
+  async () =>
+    (await import("components/ems-fd/modals/SearchMedicalRecords")).SearchMedicalRecordModal,
+  { ssr: false },
+);
 
-export default function EmsFDDashboard({
-  activeDeputy,
-  calls,
-  userDeputies,
-  activeDeputies,
-}: Props) {
+export default function EmsFDDashboard({ activeDeputy, calls, activeDeputies }: Props) {
   useLoadValuesClientSide({
     valueTypes: [
       ValueType.BLOOD_GROUP,
@@ -86,7 +85,6 @@ export default function EmsFDDashboard({
 
   React.useEffect(() => {
     state.setActiveDeputy(activeDeputy);
-    state.setDeputies(userDeputies);
     set911Calls(calls.calls);
     dispatchState.setActiveDeputies(activeDeputies);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -146,10 +144,9 @@ export default function EmsFDDashboard({
 
 export const getServerSideProps: GetServerSideProps<Props> = async ({ req, locale }) => {
   const user = await getSessionUser(req);
-  const [values, calls, { deputies }, activeDeputies, activeDeputy] = await requestAll(req, [
+  const [values, calls, activeDeputies, activeDeputy] = await requestAll(req, [
     ["/admin/values/codes_10", []],
     ["/911-calls", { calls: [], totalCount: 0 }],
-    ["/ems-fd", { deputies: [] }],
     ["/ems-fd/active-deputies", []],
     ["/ems-fd/active-deputy", null],
   ]);
@@ -159,7 +156,6 @@ export const getServerSideProps: GetServerSideProps<Props> = async ({ req, local
       session: user,
       activeDeputy,
       activeDeputies,
-      userDeputies: deputies,
       calls,
       values,
       messages: {

--- a/apps/client/src/pages/officer/index.tsx
+++ b/apps/client/src/pages/officer/index.tsx
@@ -33,7 +33,6 @@ import type {
   GetActiveOfficersData,
   GetBolosData,
   GetEmsFdActiveDeputies,
-  GetMyOfficersData,
 } from "@snailycad/types/api";
 import { CreateWarrantModal } from "components/leo/modals/CreateWarrantModal";
 import { useCall911State } from "state/dispatch/call-911-state";
@@ -102,7 +101,6 @@ const Modals = {
 interface Props {
   activeOfficer: GetActiveOfficerData;
   activeOfficers: GetActiveOfficersData;
-  userOfficers: GetMyOfficersData["officers"];
   calls: Get911CallsData;
   bolos: GetBolosData;
   activeDeputies: GetEmsFdActiveDeputies;
@@ -114,7 +112,6 @@ export default function OfficerDashboard({
   activeOfficer,
   activeOfficers,
   activeDeputies,
-  userOfficers,
 }: Props) {
   useLoadValuesClientSide({
     valueTypes: [
@@ -170,7 +167,6 @@ export default function OfficerDashboard({
 
     dispatchState.setActiveDeputies(activeDeputies);
     dispatchState.setActiveOfficers(activeOfficers);
-    leoState.setUserOfficers(userOfficers);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [bolos, calls, activeOfficers, activeDeputies, activeOfficer]);
@@ -245,23 +241,17 @@ export default function OfficerDashboard({
 
 export const getServerSideProps: GetServerSideProps<Props> = async ({ req, locale }) => {
   const user = await getSessionUser(req);
-  const [
-    activeOfficer,
-    { officers: userOfficers },
-    values,
-    calls,
-    bolos,
-    activeOfficers,
-    activeDeputies,
-  ] = await requestAll(req, [
-    ["/leo/active-officer", null],
-    ["/leo", { officers: [] }],
-    ["/admin/values/codes_10", []],
-    ["/911-calls", { calls: [], totalCount: 0 }],
-    ["/bolos", { bolos: [], totalCount: 0 }],
-    ["/leo/active-officers", []],
-    ["/ems-fd/active-deputies", []],
-  ]);
+  const [activeOfficer, values, calls, bolos, activeOfficers, activeDeputies] = await requestAll(
+    req,
+    [
+      ["/leo/active-officer", null],
+      ["/admin/values/codes_10", []],
+      ["/911-calls", { calls: [], totalCount: 0 }],
+      ["/bolos", { bolos: [], totalCount: 0 }],
+      ["/leo/active-officers", []],
+      ["/ems-fd/active-deputies", []],
+    ],
+  );
 
   return {
     props: {
@@ -269,7 +259,6 @@ export const getServerSideProps: GetServerSideProps<Props> = async ({ req, local
       activeOfficers,
       activeDeputies,
       activeOfficer,
-      userOfficers,
       calls,
       bolos,
       values,

--- a/apps/client/src/pages/officer/my-officer-logs.tsx
+++ b/apps/client/src/pages/officer/my-officer-logs.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useTranslations } from "use-intl";
 import { Layout } from "components/Layout";
 import { getSessionUser } from "lib/auth";
@@ -12,33 +11,14 @@ import { useGenerateCallsign } from "hooks/useGenerateCallsign";
 import { Title } from "components/shared/Title";
 import { OfficerLogsTable } from "components/leo/logs/OfficerLogsTable";
 import { Permissions } from "@snailycad/permissions";
-import type { GetMyOfficersData, GetMyOfficersLogsData } from "@snailycad/types/api";
-import useFetch from "lib/useFetch";
+import type { GetMyOfficersLogsData } from "@snailycad/types/api";
 import { useAsyncTable } from "components/shared/Table";
+import { useUserOfficers } from "hooks/leo/use-get-user-officers";
 
 export type OfficerLogWithOfficer = OfficerLog & { officer: Officer };
 
 interface Props {
   logs: GetMyOfficersLogsData;
-}
-
-function useGetUserOfficers() {
-  const [officers, setOfficers] = React.useState<Officer[]>([]);
-  const { execute } = useFetch();
-
-  const getOfficers = React.useCallback(async () => {
-    const { json } = await execute<GetMyOfficersData>({ path: "/leo", method: "GET" });
-
-    if (Array.isArray(json.officers)) {
-      setOfficers(json.officers);
-    }
-  }, []); // eslint-disable-line
-
-  React.useEffect(() => {
-    getOfficers();
-  }, [getOfficers]);
-
-  return officers;
 }
 
 export default function MyOfficersLogs({ logs: data }: Props) {
@@ -55,12 +35,12 @@ export default function MyOfficersLogs({ logs: data }: Props) {
     initialData: data.logs,
   });
 
-  const officers = useGetUserOfficers();
+  const { userOfficers, isLoading } = useUserOfficers();
 
   const t = useTranslations("Leo");
   const { generateCallsign } = useGenerateCallsign();
 
-  const officerNames = officers.reduce(
+  const officerNames = userOfficers.reduce(
     (ac, cv) => ({
       ...ac,
       [cv.id]: `${generateCallsign(cv)} ${makeUnitName(cv)}`,
@@ -80,6 +60,7 @@ export default function MyOfficersLogs({ logs: data }: Props) {
           <div className="ml-3 w-52">
             <FormField label="Group By Officer">
               <Select
+                isLoading={isLoading}
                 isClearable
                 onChange={(e) => {
                   asyncTable.setFilters((prev) => ({

--- a/apps/client/src/state/leo-state.ts
+++ b/apps/client/src/state/leo-state.ts
@@ -15,9 +15,6 @@ interface LeoState {
   activeOfficer: ActiveOfficer | null;
   setActiveOfficer(officer: ActiveOfficer | null): void;
 
-  userOfficers: Officer[];
-  setUserOfficers(userOfficers: Officer[]): void;
-
   activeWarrants: ActiveWarrant[];
   setActiveWarrants(warrants: ActiveWarrant[]): void;
 }
@@ -25,9 +22,6 @@ interface LeoState {
 export const useLeoState = create<LeoState>()((set) => ({
   activeOfficer: null,
   setActiveOfficer: (officer) => set({ activeOfficer: officer }),
-
-  userOfficers: [],
-  setUserOfficers: (userOfficers) => set({ userOfficers }),
 
   activeWarrants: [],
   setActiveWarrants: (warrants) => set({ activeWarrants: warrants }),

--- a/packages/types/src/api/leo.ts
+++ b/packages/types/src/api/leo.ts
@@ -2,35 +2,36 @@ import type * as Types from "../index.js";
 
 /**
  * @method GET
- * @route /my-officers
+ * @route /leo
  */
 export interface GetMyOfficersData {
   officers: (Types.Officer & {
     qualifications: Types.UnitQualification[];
   })[];
+  totalCount: number;
 }
 
 /**
  * @method POST
- * @route /my-officers
+ * @route /leo
  */
 export type PostMyOfficersData = GetMyOfficersData["officers"][number];
 
 /**
  * @method PUT
- * @route /my-officers/:id
+ * @route /leo/:id
  */
 export type PutMyOfficerByIdData = GetMyOfficersData["officers"][number];
 
 /**
  * @method DELETE
- * @route /my-officers/:id
+ * @route /leo/:id
  */
 export type DeleteMyOfficerByIdData = boolean;
 
 /**
  * @method GET
- * @route /my-officers/logs
+ * @route /leo/logs
  */
 export interface GetMyOfficersLogsData {
   logs: (Types.OfficerLog & { officer: Types.Officer | null })[];
@@ -39,7 +40,7 @@ export interface GetMyOfficersLogsData {
 
 /**
  * @method POST
- * @route /my-officers/image/:id
+ * @route /leo/image/:id
  */
 export interface PostMyOfficerByIdData {
   imageId: string | null;


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

This PR includes:

- only load user officers/deputies when needed
- Don't load user officers/deputies on SSR because they're not needed until a modal is opened.
