### PR TITLE
chore: cache /values/<path>

### DIFF
--- a/apps/api/src/controllers/admin/AdminController.ts
+++ b/apps/api/src/controllers/admin/AdminController.ts
@@ -13,7 +13,7 @@ import type { GetAdminDashboardData } from "@snailycad/types/api";
 import axios from "axios";
 import { getCADVersion } from "@snailycad/utils/version";
 
-const ONE_DAY = 60 * 60 * 24;
+export const ONE_DAY = 60 * 60 * 24;
 
 @Controller("/admin")
 @ContentType("application/json")
@@ -70,7 +70,7 @@ export class AdminController {
 
     res.setHeader(
       "Cache-Control",
-      `private, max-age=${ONE_DAY} stale-while-revalidate=${ONE_DAY / 2}`,
+      `private, max-age=${ONE_DAY}, stale-while-revalidate=${ONE_DAY / 2}`,
     );
 
     const imageData = await this.imageData().catch(() => null);

--- a/apps/api/src/controllers/admin/values/values-controller.ts
+++ b/apps/api/src/controllers/admin/values/values-controller.ts
@@ -8,6 +8,7 @@ import {
   MultipartFile,
   PlatformMulterFile,
   Context,
+  Res,
 } from "@tsed/common";
 import fs from "node:fs/promises";
 import { ContentType, Delete, Description, Patch, Post, Put } from "@tsed/schema";
@@ -27,6 +28,7 @@ import { BULK_DELETE_SCHEMA } from "@snailycad/schemas";
 import { validateSchema } from "lib/data/validate-schema";
 import { createSearchWhereObject } from "lib/values/create-where-object";
 import generateBlurPlaceholder from "lib/images/generate-image-blur-data";
+import { ONE_DAY } from "../AdminController";
 
 export const GET_VALUES: Partial<Record<ValueType, ValuesSelect>> = {
   QUALIFICATION: {
@@ -62,12 +64,14 @@ export class ValuesController {
   @Get("/")
   @Description("Get all the values by the specified types")
   async getValueByPath(
+    @Res() res: Res,
     @PathParams("path") path: (string & {}) | "all",
     @QueryParams() queryParams: any,
     @QueryParams("paths") rawPaths: string,
     @QueryParams("skip", Number) skip = 0,
     @QueryParams("query", String) query = "",
     @QueryParams("includeAll", Boolean) includeAll = true,
+    @QueryParams("cache", Boolean) cache = true,
   ): Promise<APITypes.GetValuesData | APITypes.GetValuesPenalCodesData> {
     // allow more paths in one request
     let paths =
@@ -170,6 +174,13 @@ export class ValuesController {
         };
       }),
     );
+
+    if (cache) {
+      res.setHeader(
+        "Cache-Control",
+        `public, s-max-age=${ONE_DAY}, stale-while-revalidate=${ONE_DAY / 2}`,
+      );
+    }
 
     return values as APITypes.GetValuesData;
   }

--- a/apps/client/locales/en/values.json
+++ b/apps/client/locales/en/values.json
@@ -26,6 +26,7 @@
     "county": "County",
     "deletedSelectedValues": "Deleted {deleted} items. Failed to delete {failed} items.",
     "failedDeleteValue": "Failed to delete <span>{value}</span>.",
+    "cacheTip": " Values are cached for 24 hours. This means that updated, added or deleted values may not immediately change. It could take up to 24 hours for the changes to take effect.",
     "alert_deleteValue": "Are you sure you want to delete <span>{value}</span>? This action cannot be undone!",
     "alert_deleteSelectedValues": "Are you sure you want to delete {length} items? This action cannot be undone"
   },

--- a/apps/client/src/pages/admin/values/[path].tsx
+++ b/apps/client/src/pages/admin/values/[path].tsx
@@ -89,7 +89,7 @@ export default function ValuePath({ pathValues: { totalCount, type, values: data
         if (!forType) return { data, totalCount };
         return { data: forType.values, totalCount: forType.totalCount };
       },
-      path: `/admin/values/${type.toLowerCase()}?includeAll=false`,
+      path: `/admin/values/${type.toLowerCase()}?includeAll=false&cache=false`,
     },
     initialData: data,
     totalCount,
@@ -226,6 +226,15 @@ export default function ValuePath({ pathValues: { totalCount, type, values: data
         </div>
       </header>
 
+      <div role="alert" className="px-4 py-2 card my-3 !bg-slate-900 !border-slate-500 border-2">
+        <h3 className="font-bold text-xl mb-2">Tip</h3>
+
+        <p>
+          Values are cached for 24 hours. This means that updated, added or deleted values may not
+          immediately change. It could take up to 24 hours for the changes to take effect.
+        </p>
+      </div>
+
       <SearchArea search={{ search, setSearch }} asyncTable={asyncTable} totalCount={totalCount} />
 
       {asyncTable.items.length <= 0 ? (
@@ -323,7 +332,7 @@ export const getServerSideProps: GetServerSideProps = async ({ locale, req, quer
   const user = await getSessionUser(req);
   const [pathValues] = await requestAll(req, [
     [
-      `/admin/values/${path}?includeAll=false`,
+      `/admin/values/${path}?includeAll=false&cache=false`,
       {
         totalCount: 0,
         values: [],

--- a/apps/client/src/pages/admin/values/[path].tsx
+++ b/apps/client/src/pages/admin/values/[path].tsx
@@ -229,10 +229,7 @@ export default function ValuePath({ pathValues: { totalCount, type, values: data
       <div role="alert" className="px-4 py-2 card my-3 !bg-slate-900 !border-slate-500 border-2">
         <h3 className="font-bold text-xl mb-2">Tip</h3>
 
-        <p>
-          Values are cached for 24 hours. This means that updated, added or deleted values may not
-          immediately change. It could take up to 24 hours for the changes to take effect.
-        </p>
+        <p>{t("cacheTip")}</p>
       </div>
 
       <SearchArea search={{ search, setSearch }} asyncTable={asyncTable} totalCount={totalCount} />

--- a/apps/client/src/pages/admin/values/penal-code/[groupId].tsx
+++ b/apps/client/src/pages/admin/values/penal-code/[groupId].tsx
@@ -59,7 +59,7 @@ export default function PenalCodeGroupsPage(props: Props) {
         data: json[0]?.values ?? [],
         totalCount: json[0]?.totalCount ?? 0,
       }),
-      path: `/admin/values/penal_code?groupId=${groupId}&includeAll=false`,
+      path: `/admin/values/penal_code?groupId=${groupId}&includeAll=false&cache=false`,
       requireFilterText: true,
     },
     initialData: props.penalCodes.values,
@@ -167,6 +167,15 @@ export default function PenalCodeGroupsPage(props: Props) {
         </div>
       </header>
 
+      <div role="alert" className="px-4 py-2 card my-3 !bg-slate-900 !border-slate-500 border-2">
+        <h3 className="font-bold text-xl mb-2">Tip</h3>
+
+        <p>
+          Values are cached for 24 hours. This means that updated, added or deleted values may not
+          immediately change. It could take up to 24 hours for the changes to take effect.
+        </p>
+      </div>
+
       <SearchArea search={{ search, setSearch }} asyncTable={asyncTable} totalCount={0} />
 
       <Table
@@ -250,7 +259,7 @@ export const getServerSideProps: GetServerSideProps = async ({ locale, req, quer
   const user = await getSessionUser(req);
   const [penalCodes] = await requestAll(req, [
     [
-      `/admin/values/penal_code?groupId=${query.groupId}&includeAll=false`,
+      `/admin/values/penal_code?groupId=${query.groupId}&includeAll=false&cache=false`,
       { totalCount: 0, values: [], type: "PENAL_CODE" },
     ],
   ]);

--- a/apps/client/src/pages/admin/values/penal-code/[groupId].tsx
+++ b/apps/client/src/pages/admin/values/penal-code/[groupId].tsx
@@ -170,10 +170,7 @@ export default function PenalCodeGroupsPage(props: Props) {
       <div role="alert" className="px-4 py-2 card my-3 !bg-slate-900 !border-slate-500 border-2">
         <h3 className="font-bold text-xl mb-2">Tip</h3>
 
-        <p>
-          Values are cached for 24 hours. This means that updated, added or deleted values may not
-          immediately change. It could take up to 24 hours for the changes to take effect.
-        </p>
+        <p>{valuesT("cacheTip")}</p>
       </div>
 
       <SearchArea search={{ search, setSearch }} asyncTable={asyncTable} totalCount={0} />


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

## Bug

- [ ] Related issues linked using `closes: #number`

## Feature

- [x] Related issues linked using closes #1451 
- [x] There is only 1 db migration with no breaking changes.

## Translations

- [ ] `.json` files are formatted: `yarn format`
- [ ] Translations are correct
- [ ] New translation? It's been added to `i18n.config.mjs`
