### PR TITLE
feat: Signal 100 for citizens (optional feature)

### DIFF
--- a/apps/api/prisma/migrations/20230302182638_signal_100_citizen/migration.sql
+++ b/apps/api/prisma/migrations/20230302182638_signal_100_citizen/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "Feature" ADD VALUE 'SIGNAL_100_CITIZEN';

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1772,4 +1772,5 @@ enum Feature {
   FORCE_STEAM_AUTH // See #1502
   EDITABLE_SSN // See #1544
   EDITABLE_VIN // See #1544
+  SIGNAL_100_CITIZEN // See #1562
 }

--- a/apps/api/src/middlewares/is-enabled.ts
+++ b/apps/api/src/middlewares/is-enabled.ts
@@ -29,6 +29,7 @@ export const DEFAULT_DISABLED_FEATURES: Partial<
   CALL_911_APPROVAL: { isEnabled: false },
   FORCE_DISCORD_AUTH: { isEnabled: false },
   FORCE_STEAM_AUTH: { isEnabled: false },
+  SIGNAL_100_CITIZEN: { isEnabled: false },
 };
 
 export function createFeaturesObject(features?: CadFeature[] | undefined) {

--- a/apps/api/src/migrations/disabledFeatureToCadFeature.ts
+++ b/apps/api/src/migrations/disabledFeatureToCadFeature.ts
@@ -25,6 +25,7 @@ const DEFAULTS: Partial<Record<Feature, { isEnabled: boolean }>> = {
   CALL_911_APPROVAL: { isEnabled: false },
   FORCE_DISCORD_AUTH: { isEnabled: false },
   FORCE_STEAM_AUTH: { isEnabled: false },
+  SIGNAL_100_CITIZEN: { isEnabled: false },
 };
 
 export async function disabledFeatureToCadFeature() {

--- a/apps/client/locales/en/cad-settings.json
+++ b/apps/client/locales/en/cad-settings.json
@@ -181,6 +181,8 @@
     "EDITABLE_SSN": "Editable SSN",
     "EDITABLE_SSN-description": "When enabled, this will allow citizens to edit their SSN.",
     "EDITABLE_VIN": "Editable VIN",
-    "EDITABLE_VIN-description": "When enabled, this will allow citizens to edit their vehicle's VIN."
+    "EDITABLE_VIN-description": "When enabled, this will allow citizens to edit their vehicle's VIN.",
+    "SIGNAL_100_CITIZEN": "Signal 100 display for citizens",
+    "SIGNAL_100_CITIZEN-description": "When enabled, this will allow citizens to view Signal 100's."
   }
 }

--- a/apps/client/src/hooks/useFeatureEnabled.ts
+++ b/apps/client/src/hooks/useFeatureEnabled.ts
@@ -20,6 +20,7 @@ export const DEFAULT_DISABLED_FEATURES = {
   CALL_911_APPROVAL: { isEnabled: false },
   FORCE_DISCORD_AUTH: { isEnabled: false },
   FORCE_STEAM_AUTH: { isEnabled: false },
+  SIGNAL_100_CITIZEN: { isEnabled: false },
 } satisfies Partial<Record<Feature, { isEnabled: boolean }>>;
 
 export function useFeatureEnabled(features?: Record<Feature, boolean>) {

--- a/apps/client/src/pages/citizen/index.tsx
+++ b/apps/client/src/pages/citizen/index.tsx
@@ -62,7 +62,7 @@ export default function CitizenPage({ citizens }: Props) {
         <signal100.Component enabled={signal100.enabled} audio={signal100.audio} />
       ) : null}
 
-      <header className="mb-3">
+      <header className="my-3">
         <Title className="mb-2">{t("citizens")}</Title>
         {showAop ? <h2 className="font-semibold text-xl">AOP: {areaOfPlay}</h2> : null}
       </header>

--- a/apps/client/src/pages/citizen/index.tsx
+++ b/apps/client/src/pages/citizen/index.tsx
@@ -17,6 +17,7 @@ import { CitizenList } from "components/citizen/citizen-list/citizen-list";
 import type { GetCitizensData } from "@snailycad/types/api";
 import { useLoadValuesClientSide } from "hooks/useLoadValuesClientSide";
 import { ValueType } from "@snailycad/types";
+import { useSignal100 } from "hooks/shared/useSignal100";
 
 const RegisterVehicleModal = dynamic(
   async () =>
@@ -48,14 +49,19 @@ export default function CitizenPage({ citizens }: Props) {
   });
 
   const t = useTranslations("Citizen");
-  const { TOW, TAXI, WEAPON_REGISTRATION, CALLS_911 } = useFeatureEnabled();
+  const { SIGNAL_100_CITIZEN, TOW, TAXI, WEAPON_REGISTRATION, CALLS_911 } = useFeatureEnabled();
 
   const { openModal, closeModal } = useModal();
   const [modal, setModal] = React.useState<string | null>(null);
   const { showAop, areaOfPlay } = useAreaOfPlay();
+  const signal100 = useSignal100();
 
   return (
     <Layout className="dark:text-white">
+      {SIGNAL_100_CITIZEN ? (
+        <signal100.Component enabled={signal100.enabled} audio={signal100.audio} />
+      ) : null}
+
       <header className="mb-3">
         <Title className="mb-2">{t("citizens")}</Title>
         {showAop ? <h2 className="font-semibold text-xl">AOP: {areaOfPlay}</h2> : null}
@@ -139,7 +145,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async ({ locale, re
       citizens: data,
       session: user,
       messages: {
-        ...(await getTranslations(["citizen", "calls", "common"], user?.locale ?? locale)),
+        ...(await getTranslations(["citizen", "leo", "calls", "common"], user?.locale ?? locale)),
       },
     },
   };

--- a/packages/types/src/enums.ts
+++ b/packages/types/src/enums.ts
@@ -45,6 +45,7 @@ export const Feature = {
   FORCE_STEAM_AUTH: "FORCE_STEAM_AUTH",
   EDITABLE_SSN: "EDITABLE_SSN",
   EDITABLE_VIN: "EDITABLE_VIN",
+  SIGNAL_100_CITIZEN: "SIGNAL_100_CITIZEN",
 } as const;
 
 export type Feature = (typeof Feature)[keyof typeof Feature];


### PR DESCRIPTION
Allow citizens to view signal 100's when the feature is enabled<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

## Bug

- [ ] Related issues linked using `closes: #number`

## Feature

- [x] Related issues linked using closes: #1562 
- [x] There is only 1 db migration with no breaking changes.

## Translations

- [ ] `.json` files are formatted: `yarn format`
- [ ] Translations are correct
- [ ] New translation? It's been added to `i18n.config.mjs`
