### PR TITLE
🌐  add missing translation

### DIFF
--- a/apps/client/locales/ru/admin.json
+++ b/apps/client/locales/ru/admin.json
@@ -86,6 +86,7 @@
     "leo": "LEO",
     "emsFd": "EMS/FD",
     "onDuty": "На смене",
+    "impounded": "Эвакуировано",
     "suspended": "Приостановлен",
     "pruneUsers": "Удалить Пользователей",
     "inactiveUsers": "Неактивные Пользователи",


### PR DESCRIPTION
Added missing translation to `admin.json`

✅  `.json` files are formatted: `yarn format`
✅  Translations are correct

In this PR I've added the missing translation to the admin.json of the RU locale
