### PR TITLE
🧹 Add full-start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.73.0",
   "scripts": {
     "start": "pnpm concurrently \"pnpm --filter \"@snailycad/client\" start\" \"pnpm --filter \"@snailycad/api\" generate && pnpm --filter \"@snailycad/api\" start\"",
+    "full-start": "node scripts/copy-env.mjs --client --api && pnpm run build && pnpm run start",
     "build": "pnpm turbo run build --filter=\"{packages/**/**}\" && pnpm turbo run build --filter=\"{apps/**/**}\"",
     "dev": "docker compose up -d && pnpm turbo run watch --parallel --concurrency 11",
     "format": "prettier --write \"./(packages|apps)/**/**/*.{js,jsx,ts,mjs,tsx,md,css,json}\" --ignore-path .gitignore",


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

## Feature

- [x] Added `full-start` script to `package.json`

### Use Cases

This can be used to streamline the process of a full-start by copying the `.env` file, building and starting in processes like pm2, SnailyCAD Manager, and more where it might not be possible to run each command separately or together with the `&&` operator in a standalone terminal.

Feel free to review and share thoughts!