### PR TITLE
add git pull to full-start

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.73.2",
   "scripts": {
     "start": "pnpm concurrently \"pnpm --filter \"@snailycad/client\" start\" \"pnpm --filter \"@snailycad/api\" generate && pnpm --filter \"@snailycad/api\" start\"",
-    "full-start": "node scripts/copy-env.mjs --client --api && pnpm run build && pnpm run start",
+    "full-start": "git pull && node scripts/copy-env.mjs --client --api && pnpm run build && pnpm run start",
     "build": "pnpm turbo run build --filter=\"{packages/**/**}\" && pnpm turbo run build --filter=\"{apps/**/**}\"",
     "dev": "docker compose up -d && pnpm turbo run watch --parallel --concurrency 11",
     "format": "prettier --write \"./(packages|apps)/**/**/*.{js,jsx,ts,mjs,tsx,md,css,json}\" --ignore-path .gitignore",


### PR DESCRIPTION
this to to remove an extra step of updating, so on restart it will update to ensure the newest cad version

<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

## Bug

- [ ] Related issues linked using `closes: #number`

## Feature

- [ ] Related issues linked using `closes: #number`
- [ ] There is only 1 db migration with no breaking changes.

## Translations

- [ ] `.json` files are formatted: `pnpm format`
- [ ] Translations are correct
- [ ] New translation? It's been added to `i18n.config.mjs`
