### PR TITLE
🧹 chore: remove deprecated "images.domains"

### DIFF
--- a/apps/client/next.config.mjs
+++ b/apps/client/next.config.mjs
@@ -24,7 +24,23 @@ const nextConfig = {
   // prettier-ignore
   images: { // start images
     formats: ["image/avif", "image/webp"],
-    domains: ["i.imgur.com", "cdn.discordapp.com", "localhost"]
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "i.imgur.com",
+        pathname: "**"
+      },
+      {
+        protocol: "https",
+        hostname: "cdn.discordapp.com",
+        pathname: "**"
+      },
+      {
+        protocol: "http",
+        hostname: "localhost",
+        pathname: "**"
+      },
+    ]
   }, // end images
   // prettier-enable
   webpack(config, { webpack }) {

--- a/apps/client/tests/utils.test.ts
+++ b/apps/client/tests/utils.test.ts
@@ -25,7 +25,7 @@ const DOB_2 = "1953-10-21";
 
 describe("calculateAge", () => {
   test("Should correctly calculate age", () => {
-    expect(calculateAge(DOB_1)).toMatchInlineSnapshot('"24"');
+    expect(calculateAge(DOB_1)).toMatchInlineSnapshot('"25"');
   });
 
   test("Should correctly calculate age", () => {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated!
-->

## Bug

- [ ] Related issues linked using `closes: #number`

## Feature

- [ ] Related issues linked using `closes: #number`
- [ ] There is only 1 db migration with no breaking changes.

## Translations

- [ ] `.json` files are formatted: `pnpm format`
- [ ] Translations are correct
- [ ] New translation? It's been added to `i18n.config.mjs`
