### PR TITLE
🛠️ | Changed permissions for users to be able to delete their own bleets w/o administrator permissions

### DIFF
--- a/apps/api/src/controllers/bleeter/bleeter-controller.ts
+++ b/apps/api/src/controllers/bleeter/bleeter-controller.ts
@@ -214,7 +214,7 @@ export class BleeterController {
       throw new NotFound("notFound");
     }
 
-    if (post.userId !== user.id || !hasAdminPermissions) {
+    if (post.userId !== user.id && !hasAdminPermissions) {
       throw new Forbidden("notAllowedToDelete");
     }
 


### PR DESCRIPTION
Changed the logic for post deletion to allow users to delete their own bleets w/o administrator permissions. This was caused by the logic checking if the user was the owner _**or**_ if they had administrator permissions and triggered the error if either they weren't the owner or didn't have admin permissions. In this case if the user didn't have admin permissions it would trigger the error no matter if they were the owner.

## Bug

closes: [#1928](https://github.com/SnailyCAD/snaily-cadv4/issues/1928)