### PR TITLE
🧹 chore: revert turbo ui

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://turborepo.org/schema.json",
   "globalDependencies": ["**/.env"],
+  "ui": "stream",
   "tasks": {
     "@snailycad/client#build": {
       "dependsOn": ["copy-env", "^build"],


### PR DESCRIPTION
With newer versions of turbo, there is a new UI for each task that is running. There are 2 reasons I see as a good fit to revert the UI.

- It can be difficult to navigate for users who don't have much experience navigating and using the command line
- The logs will not show properly in the manager, and will make diagnosing issues difficult for those who use the manager

Casper, please let me know your thoughts, and feel free to merge if you agree.

Thanks 🙂!