### PR TITLE
Update manage-911-call-modal.tsx

### DIFF
--- a/apps/client/src/components/dispatch/active-calls/modals/manage-911-call-modal.tsx
+++ b/apps/client/src/components/dispatch/active-calls/modals/manage-911-call-modal.tsx
@@ -43,8 +43,10 @@ interface AreFormFieldsDisabledOptions {
 function areFormFieldsEnabled(options: AreFormFieldsDisabledOptions) {
   /** force disable the fields */
   if (options.forceDisabled) return false;
+  
   /** dispatch can always edit the fields */
   if (options.isDispatch) return true;
+  
   /** a new call is being created, always editable */
   if (!options.call) return true;
 
@@ -56,8 +58,15 @@ function areFormFieldsEnabled(options: AreFormFieldsDisabledOptions) {
     return isAssignedToCall;
   }
 
-  // todo: make this an optional feature
-  /** otherwise fields are not editable, even when the unit is assigned to the call */
+  // Officers and Deputies can only edit calls they are assigned to
+  if (options.activeUnit) {
+    const isAssignedToCall = options.call.assignedUnits.some(
+      (u) => u.unit?.id === options.activeUnit?.id,
+    );
+    return isAssignedToCall;
+  }
+
+  // By default, fields are not editable if the user is not a dispatcher or assigned unit
   return false;
 }
 
@@ -106,7 +115,6 @@ export function Manage911CallModal({ setCall, forceDisabled, forceOpen, call, on
 
   function handleClose() {
     onClose?.();
-
     setShowAlert(false);
     modalState.closeModal(ModalIds.Manage911Call);
   }
@@ -141,7 +149,6 @@ export function Manage911CallModal({ setCall, forceDisabled, forceOpen, call, on
       title={call ? t("manage911Call") : t("create911Call")}
       className={call ? "!max-w-[100rem] w-full" : "w-[750px]"}
     >
-      {/* todo: custom component for expanded view */}
       {call ? (
         <div className="mb-4 flex flex-wrap flex-row gap-4 max-w-[1050px]">
           {user?.developerMode ? <Infofield label={t("id")}>{call.id}</Infofield> : null}
@@ -162,8 +169,7 @@ export function Manage911CallModal({ setCall, forceDisabled, forceOpen, call, on
           setShowAlert={setShowAlert}
           handleClose={handleClose}
           isDisabled={areFieldsDisabled}
-          call={call}
-        />
+          call={call} isDispatch={false} activeUnit={null}        />
 
         {call ? (
           <CallEventsArea


### PR DESCRIPTION
As linked in [Allow LEO to edit and end call details #1959](https://github.com/SnailyCAD/snaily-cadv4/issues/1959#issuecomment-2502687108) I have made changes to allow the LEO User to make changes to the call they are on regardless of if dispatchers are active or not, as in a large community we have seen no point in having the feature restricted to only dispatchers along with some CAD's or MDT's we have looked at in person officers are able to use these functions

It has been a while since I last tested this feature to ensure it still works as we have made several changes to our version and I just don't have the time at the moment to ensure that this feature still works in a standalone segment so it would be best if someone were to test this feature

enjoy 